### PR TITLE
Add patch to fix typesupport bug in rmw_cyclonedds.

### DIFF
--- a/repositories/patches/rmw_cyclonedds-fix-typesupport-conditions-bug.patch
+++ b/repositories/patches/rmw_cyclonedds-fix-typesupport-conditions-bug.patch
@@ -1,0 +1,27 @@
+diff --git a/rmw_cyclonedds_cpp/src/serdata.cpp b/rmw_cyclonedds_cpp/src/serdata.cpp
+index 05b3286..b3382cc 100644
+--- a/rmw_cyclonedds_cpp/src/serdata.cpp
++++ b/rmw_cyclonedds_cpp/src/serdata.cpp
+@@ -60,14 +60,16 @@ using ResponseTypeSupport_cpp = rmw_cyclonedds_cpp::ResponseTypeSupport<
+   rosidl_typesupport_introspection_cpp::ServiceMembers,
+   rosidl_typesupport_introspection_cpp::MessageMembers>;
+ 
+-static bool using_introspection_c_typesupport(const char * typesupport_identifier)
+-{
+-  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
++static bool using_introspection_c_typesupport(
++    const char* typesupport_identifier) {
++  return !std::string(typesupport_identifier)
++      .compare(rosidl_typesupport_introspection_c__identifier);
+ }
+ 
+-static bool using_introspection_cpp_typesupport(const char * typesupport_identifier)
+-{
+-  return typesupport_identifier == rosidl_typesupport_introspection_cpp::typesupport_identifier;
++static bool using_introspection_cpp_typesupport(
++    const char* typesupport_identifier) {
++  return !std::string(typesupport_identifier)
++      .compare(rosidl_typesupport_introspection_cpp::typesupport_identifier);
+ }
+ 
+ void * create_message_type_support(

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -224,3 +224,4 @@ def ros2_repositories():
         patches=["@com_github_mvukov_rules_ros2//repositories/patches:rmw_cyclonedds-fix-typesupport-conditions-bug.patch"],
         urls = ["https://github.com/ros2/rmw_cyclonedds/archive/0.7.6.tar.gz"],
     )
+    

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -220,5 +220,7 @@ def ros2_repositories():
         build_file = "@com_github_mvukov_rules_ros2//repositories:rmw_cyclonedds.BUILD.bazel",
         sha256 = "5995d8ae3613126ee5b68db68d0c1c4a6caa8eec3fb0a269921a16fa1a810af6",
         strip_prefix = "rmw_cyclonedds-0.7.6",
+        patch_args = ["-p1"],
+        patches=["@com_github_mvukov_rules_ros2//repositories/patches:rmw_cyclonedds-fix-typesupport-conditions-bug.patch"],
         urls = ["https://github.com/ros2/rmw_cyclonedds/archive/0.7.6.tar.gz"],
     )


### PR DESCRIPTION
As we discuss in #1 ,the problem is solved
Fix this bug by modified [rmw_cyclonedds](https://github.com/ros2/rmw_cyclonedds/tree/foxy) package. the patch is as below based on foxy branch:
``` cpp
diff --git a/rmw_cyclonedds_cpp/src/serdata.cpp b/rmw_cyclonedds_cpp/src/serdata.cpp
index 05b3286..b3382cc 100644
--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -60,14 +60,16 @@ using ResponseTypeSupport_cpp = rmw_cyclonedds_cpp::ResponseTypeSupport<
   rosidl_typesupport_introspection_cpp::ServiceMembers,
   rosidl_typesupport_introspection_cpp::MessageMembers>;
 
-static bool using_introspection_c_typesupport(const char * typesupport_identifier)
-{
-  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
+static bool using_introspection_c_typesupport(
+    const char* typesupport_identifier) {
+  return !std::string(typesupport_identifier)
+      .compare(rosidl_typesupport_introspection_c__identifier);
 }
 
-static bool using_introspection_cpp_typesupport(const char * typesupport_identifier)
-{
-  return typesupport_identifier == rosidl_typesupport_introspection_cpp::typesupport_identifier;
+static bool using_introspection_cpp_typesupport(
+    const char* typesupport_identifier) {
+  return !std::string(typesupport_identifier)
+      .compare(rosidl_typesupport_introspection_cpp::typesupport_identifier);
 }
 
 void * create_message_type_support(
```
The problem is solved when the conditions are correctly determined.

talker
```bash
evan@in_docker:~/rules_ros2$ bazel run //examples/chatter:talker 
INFO: Analyzed target //examples/chatter:talker (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/chatter:talker up-to-date:
  bazel-bin/examples/chatter/talker
INFO: Elapsed time: 0.113s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
1623155607.229638 [0]     talker: using network interface eno1 (udp/172.18.20.17) selected arbitrarily from: eno1, docker0
[INFO] [1623155607.736482142] [minimal_publisher]: Publishing: 'Hello, world! 0'
[INFO] [1623155608.236450915] [minimal_publisher]: Publishing: 'Hello, world! 1'
[INFO] [1623155608.736465676] [minimal_publisher]: Publishing: 'Hello, world! 2'
[INFO] [1623155609.236454210] [minimal_publisher]: Publishing: 'Hello, world! 3'
[INFO] [1623155609.736454613] [minimal_publisher]: Publishing: 'Hello, world! 4'
[INFO] [1623155610.236439533] [minimal_publisher]: Publishing: 'Hello, world! 5'
^C[INFO] [1623155610.466806625] [rclcpp]: signal_handler(signal_value=2)
```

listener
```bash
evan@in_docker:~/rules_ros2$ bazel run //examples/chatter:listener 
INFO: Analyzed target //examples/chatter:listener (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/chatter:listener up-to-date:
  bazel-bin/examples/chatter/listener
INFO: Elapsed time: 0.096s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
1623155596.586644 [0]   listener: using network interface eno1 (udp/172.18.20.17) selected arbitrarily from: eno1, docker0
[INFO] [1623155607.736783469] [minimal_subscriber]: I heard: 'Hello, world! 0'
[INFO] [1623155608.236732927] [minimal_subscriber]: I heard: 'Hello, world! 1'
[INFO] [1623155608.736722786] [minimal_subscriber]: I heard: 'Hello, world! 2'
[INFO] [1623155609.236693576] [minimal_subscriber]: I heard: 'Hello, world! 3'
[INFO] [1623155609.736732649] [minimal_subscriber]: I heard: 'Hello, world! 4'
[INFO] [1623155610.236678127] [minimal_subscriber]: I heard: 'Hello, world! 5'
^C[INFO] [1623155631.231753811] [rclcpp]: signal_handler(signal_value=2)
```

rqt
![rqt](https://user-images.githubusercontent.com/9546943/121185762-fd964500-c898-11eb-803b-efaba1520c49.png)


