### PR TITLE
Add visualization_msgs and fix sensor_msgs includes

### DIFF
--- a/repositories/common_interfaces.BUILD.bazel
+++ b/repositories/common_interfaces.BUILD.bazel
@@ -7,6 +7,10 @@ load(
     "py_ros2_interface_library",
     "ros2_interface_library",
 )
+load(
+    "@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl",
+    "ros2_cpp_library",
+)
 
 ros2_interface_library(
     name = "std_msgs",
@@ -73,7 +77,37 @@ ros2_interface_library(
 )
 
 cpp_ros2_interface_library(
-    name = "cpp_sensor_msgs",
-    visibility = ["//visibility:public"],
+    name = "_cpp_sensor_msgs",
+    visibility = ["//visibility:private"],
     deps = [":sensor_msgs"],
+)
+
+ros2_cpp_library(
+    name = "cpp_sensor_msgs",
+    hdrs = glob([
+        "sensor_msgs/include/**/*.hpp",
+    ]),
+    strip_include_prefix = "sensor_msgs/include",
+    deps = [":_cpp_sensor_msgs"],
+    visibility = ["//visibility:public"],
+)
+
+ros2_interface_library(
+    name = "visualization_msgs",
+    srcs = glob([
+        "visualization_msgs/msg/*.msg",
+        "visualization_msgs/srv/*.srv",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":geometry_msgs",
+        ":std_msgs",
+        ":sensor_msgs",
+    ],
+)
+
+cpp_ros2_interface_library(
+    name = "cpp_visualization_msgs",
+    visibility = ["//visibility:public"],
+    deps = [":visualization_msgs"],
 )


### PR DESCRIPTION
I can split this into two separate PRs if you prefer (or at least two commits in a single PR). Also, I started out with extending `ros2_interface_library` to support a `hdrs` attributes, but then realized that the not-yet-included header files are actually only useful for C++, so having the private `cpp_ros2_interface_library` and wrapping this with a `ros2_cpp_library` that includes the headers seemed like a good solution. Please let me know if you'd prefer a different approach.