### PR TITLE
Add tf2 package

### DIFF
--- a/repositories/geometry2.BUILD.bazel
+++ b/repositories/geometry2.BUILD.bazel
@@ -1,0 +1,87 @@
+load(
+    "@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl",
+    "ros2_cpp_library",
+)
+load(
+    "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
+    "cpp_ros2_interface_library",
+    "ros2_interface_library",
+)
+
+ros2_interface_library(
+    name = "tf2_msgs",
+    srcs = glob([
+        "tf2_msgs/msg/*.msg",
+        "tf2_msgs/srv/*.srv",
+        "tf2_msgs/action/*.action",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ros2_common_interfaces//:geometry_msgs",
+        "@ros2_rcl_interfaces//:action_msgs",
+        "@ros2_rcl_interfaces//:builtin_interfaces",
+        "@ros2_unique_identifier_msgs//:unique_identifier_msgs",
+    ],
+)
+
+cpp_ros2_interface_library(
+    name = "cpp_tf2_msgs",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tf2_msgs",
+    ],
+)
+
+ros2_cpp_library(
+    name = "tf2",
+    srcs = glob([
+        "tf2/src/*.cpp",
+        "tf2/src/*.hpp",
+    ]),
+    hdrs = glob(["tf2/include/**/*.h"]),
+    includes = ["tf2/include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@console_bridge",
+        "@ros2_common_interfaces//:cpp_geometry_msgs",
+        "@ros2_rcutils//:rcutils",
+    ],
+)
+
+ros2_cpp_library(
+    name = "tf2_ros",
+    srcs = [
+        "tf2_ros/src/buffer.cpp",
+        "tf2_ros/src/buffer_client.cpp",
+        "tf2_ros/src/buffer_server.cpp",
+        "tf2_ros/src/create_timer_ros.cpp",
+        "tf2_ros/src/static_transform_broadcaster.cpp",
+        "tf2_ros/src/transform_broadcaster.cpp",
+        "tf2_ros/src/transform_listener.cpp",
+    ],
+    hdrs = [
+        "async_buffer_interface.h",
+        "buffer.h",
+        "buffer_client.h",
+        "buffer_interface.h",
+        "buffer_server.h",
+        "create_timer_interface.h",
+        "create_timer_ros.h",
+        "message_filter.h",
+        "qos.hpp",
+        "static_transform_broadcaster.h",
+        "transform_broadcaster.h",
+        "transform_listener.h",
+        "visibility_control.h",
+    ],
+    includes = ["tf2_ros/include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cpp_tf2_msgs",
+        ":tf2",
+        "@ros2_common_interfaces//:cpp_geometry_msgs",
+        "@ros2_message_filters//:message_filters",
+        "@ros2_rclcpp//:rclcpp",
+        "@ros2_rclcpp//:rclcpp_action",
+    ],
+)

--- a/repositories/message_filters.BUILD.bazel
+++ b/repositories/message_filters.BUILD.bazel
@@ -1,0 +1,18 @@
+load(
+    "@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl",
+    "ros2_cpp_library",
+)
+
+ros2_cpp_library(
+    name = "message_filters",
+    srcs = glob([
+        "src/*.cpp",
+    ]),
+    hdrs = glob(["include/**/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ros2_rclcpp//:rclcpp",
+        "@ros2_rcutils//:rcutils",
+    ],
+)

--- a/repositories/ros2_repo_mappings.yaml
+++ b/repositories/ros2_repo_mappings.yaml
@@ -15,6 +15,9 @@ repositories:
   cyclonedds:
     name: cyclonedds
     build_file: "@com_github_mvukov_rules_ros2//repositories:cyclonedds.BUILD.bazel"
+  geometry2:
+    name: ros2_geometry2
+    build_file: "@com_github_mvukov_rules_ros2//repositories:geometry2.BUILD.bazel"
   iceoryx:
     name: iceoryx
     strip_prefix: iceoryx-2.0.2
@@ -28,6 +31,9 @@ repositories:
   libstatistics_collector:
     name: ros2_libstatistics_collector
     build_file: "@com_github_mvukov_rules_ros2//repositories:libstatistics_collector.BUILD.bazel"
+  message_filters:
+    name: ros2_message_filters
+    build_file: "@com_github_mvukov_rules_ros2//repositories:message_filters.BUILD.bazel"
   osrf_pycommon:
     name: osrf_pycommon
     build_file: "@com_github_mvukov_rules_ros2//repositories:osrf_pycommon.BUILD.bazel"

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -50,6 +50,15 @@ def ros2_repositories_impl():
 
     maybe(
         http_archive,
+        name = "ros2_geometry2",
+        build_file = "@com_github_mvukov_rules_ros2//repositories:geometry2.BUILD.bazel",
+        sha256 = "028a0aaa2f0ddd142da24921a9fa8e1b790734de364bd37de6d6a89c7487c3ab",
+        strip_prefix = "geometry2-0.25.0",
+        url = "https://github.com/ros2/geometry2/archive/refs/tags/0.25.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
         name = "iceoryx",
         strip_prefix = "iceoryx-2.0.2",
         build_file = "@com_github_mvukov_rules_ros2//repositories:iceoryx.BUILD.bazel",
@@ -82,6 +91,15 @@ def ros2_repositories_impl():
         sha256 = "25a28787c6c616038bf4425a561e53dc92a3d315de4cf00d030f18edde2774c6",
         strip_prefix = "libstatistics_collector-1.2.0",
         url = "https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.2.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "ros2_message_filters",
+        build_file = "@com_github_mvukov_rules_ros2//repositories:message_filters.BUILD.bazel",
+        sha256 = "261cae7438b3b2907cc8f9d4972826a156147ec4b13b02eabca066f011b7d6bb",
+        strip_prefix = "message_filters-4.3.1",
+        url = "https://github.com/ros2/message_filters/archive/refs/tags/4.3.1.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
This adds part of the geometry2 package (tf2).

File `repositories/console_bridge.BUILD.bazel` is stolen from https://github.com/mvukov/rules_ros2/compare/feature/pluginlib#diff-d1a7e3a17144dfb0f628076fc98f452c60b4d182f370b2f962ed23d518911ea1