### PR TITLE
Suppress warnings from cpp_sensor_msgs

### DIFF
--- a/repositories/common_interfaces.BUILD.bazel
+++ b/repositories/common_interfaces.BUILD.bazel
@@ -100,7 +100,7 @@ ros2_cpp_library(
     hdrs = glob([
         "sensor_msgs/include/**/*.hpp",
     ]),
-    strip_include_prefix = "sensor_msgs/include",
+    includes = ["sensor_msgs/include"],
     visibility = ["//visibility:public"],
     deps = [":_cpp_sensor_msgs"],
 )


### PR DESCRIPTION
When compiled with `-Wconversion`, the point cloud helpers produce some warnings. To supress them, we use `includes` instead of `strip_include_prefix`.