### PR TITLE
Fix flaky image_transport test

### DIFF
--- a/ros2/test/image_common/tests.py
+++ b/ros2/test/image_common/tests.py
@@ -16,8 +16,10 @@ import unittest
 import launch.actions
 import launch_testing.actions
 import launch_testing.asserts
+import launch_testing.markers
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description():
     test_node = launch.actions.ExecuteProcess(
         name='plugin_tests',

--- a/ros2/test/pluginlib/tests.py
+++ b/ros2/test/pluginlib/tests.py
@@ -16,8 +16,10 @@ import unittest
 import launch.actions
 import launch_testing.actions
 import launch_testing.asserts
+import launch_testing.markers
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description():
     plugin_tests_node = launch.actions.ExecuteProcess(
         name='plugin_tests',


### PR DESCRIPTION
This test failed when the GTest binary fininished before we enter `TestPlugins.test_plugins()`. Adding the `keep_alive` decorator fixes that.