### PR TITLE
Add initial launch_pytest support

### DIFF
--- a/repositories/launch.BUILD.bazel
+++ b/repositories/launch.BUILD.bazel
@@ -18,6 +18,21 @@ py_library(
 )
 
 py_library(
+    name = "launch_pytest",
+    srcs = glob(["launch_pytest/launch_pytest/**/*.py"]),
+    imports = ["launch_pytest"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":launch",
+        ":launch_testing",
+        "@osrf_pycommon",
+        "@ros2_ament_index//:ament_index_python",
+        requirement("pytest"),
+        requirement("pyyaml"),
+    ],
+)
+
+py_library(
     name = "launch_testing",
     srcs = glob(["launch_testing/launch_testing/**/*.py"]),
     imports = ["launch_testing"],

--- a/ros2/test/launch_pytest/BUILD.bazel
+++ b/ros2/test/launch_pytest/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+
+cc_binary(
+    name = "hello",
+    srcs = ["hello.cpp"],
+)
+
+py_test(
+    name = "launch_pytest_test",
+    srcs = ["launch_pytest_test.py"],
+    data = [":hello"],
+    # launch_file = "launch_pytest_test.py",
+    # nodes = [":hello"],
+    deps = [
+        requirement("pytest"),
+        "@ros2_launch//:launch_pytest",
+    ],
+)

--- a/ros2/test/launch_pytest/hello.cpp
+++ b/ros2/test/launch_pytest/hello.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main() {
+  for (auto count{0}; count < 5; ++count) {
+    std::cout << "Hello, count " << count << std::endl;
+  }
+}

--- a/ros2/test/launch_pytest/launch_pytest_test.py
+++ b/ros2/test/launch_pytest/launch_pytest_test.py
@@ -1,0 +1,39 @@
+import sys
+
+import pytest
+
+import launch
+import launch_pytest
+import launch_pytest.tools
+
+
+
+@pytest.fixture
+def hello_proc():
+    return launch.actions.ExecuteProcess(
+        cmd=["ros2/test/launch_pytest/hello"],
+        cached_output=True,
+    )
+
+
+@launch_pytest.fixture
+def launch_description(hello_proc):
+    return launch.LaunchDescription([
+        hello_proc,
+        launch_pytest.actions.ReadyToTest()
+    ])
+
+
+@pytest.mark.launch(fixture=launch_description)
+def test_check_output(hello_proc, launch_context):
+    launch_pytest.tools.wait_for_start_sync(launch_context, hello_proc, timeout=10)
+
+    def check_output(output):
+        assert output.splitlines() == [f"Hello, count {i}" for i in range(5)]
+
+    launch_pytest.tools.assert_output_sync(
+        launch_context, hello_proc, check_output, timeout=10)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-rP", "-p", "launch_pytest.plugin", "--", sys.argv[0]]))


### PR DESCRIPTION
Here's an initial implementation with support for `launch_pytest`, which seems to me like a nicer alternative to `launch_testing`. Let me know what you think, then I can finish it. How to integrate it with the rest of the Bazel setup is the part that's somewhat unclear. See my code comments.