### PR TITLE
Enable building cyclonedds for QNX

### DIFF
--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -70,7 +70,14 @@ cmake(
     }),
     generate_args = ["-GNinja"],
     lib_source = ":all_srcs",
-    linkopts = ["-lpthread"],
+    linkopts = select(
+        {
+            "@platforms//os:linux": ["-lpthread"],
+            "@platforms//os:macos": ["-lpthread"],
+            "@platforms//os:qnx": [],
+        },
+        no_match_error = "Only Linux, macOS and QNX are supported!",
+    ),
     out_static_libs = ["libddsc.a"],
     visibility = ["//visibility:public"],
     deps = select({

--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -12,13 +12,13 @@ bool_flag(
 )
 
 config_setting(
-    name = "with_shm",
+    name = "enable_shm_on",
     flag_values = {":enable_shm": "True"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "without_shm",
+    name = "enable_shm_off",
     flag_values = {":enable_shm": "False"},
     visibility = ["//visibility:public"],
 )
@@ -35,7 +35,7 @@ selects.config_setting_group(
     name = "linux_or_macos_with_shm",
     match_all = [
         ":linux_or_macos",
-        ":with_shm",
+        ":enable_shm_on",
     ]
 )
 
@@ -43,7 +43,7 @@ selects.config_setting_group(
     name = "qnx_with_shm",
     match_all = [
         "@platforms//os:qnx",
-        ":with_shm",
+        ":enable_shm_on",
     ]
 )
 
@@ -51,7 +51,7 @@ selects.config_setting_group(
     name = "linux_or_macos_without_shm",
     match_all = [
         ":linux_or_macos",
-        ":without_shm",
+        ":enable_shm_off",
     ]
 )
 
@@ -59,7 +59,7 @@ selects.config_setting_group(
     name = "qnx_without_shm",
     match_all = [
         "@platforms//os:qnx",
-        ":without_shm",
+        ":enable_shm_off",
     ]
 )
 
@@ -156,7 +156,7 @@ cmake(
     out_static_libs = ["libddsc.a"],
     visibility = ["//visibility:public"],
     deps = select({
-        ":with_shm": ["@iceoryx"],
+        ":enable_shm_on": ["@iceoryx"],
         "//conditions:default": [],
     }),
 )

--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -2,6 +2,7 @@
 """
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
@@ -11,9 +12,55 @@ bool_flag(
 )
 
 config_setting(
-    name = "enable_shm_on",
+    name = "with_shm",
     flag_values = {":enable_shm": "True"},
     visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "without_shm",
+    flag_values = {":enable_shm": "False"},
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "linux_or_macos",
+    match_any = [
+        "@platforms//os:linux",
+        "@platforms//os:macos",
+    ]
+)
+
+selects.config_setting_group(
+    name = "linux_or_macos_with_shm",
+    match_all = [
+        ":linux_or_macos",
+        ":with_shm",
+    ]
+)
+
+selects.config_setting_group(
+    name = "qnx_with_shm",
+    match_all = [
+        "@platforms//os:qnx",
+        ":with_shm",
+    ]
+)
+
+selects.config_setting_group(
+    name = "linux_or_macos_without_shm",
+    match_all = [
+        ":linux_or_macos",
+        ":without_shm",
+    ]
+)
+
+selects.config_setting_group(
+    name = "qnx_without_shm",
+    match_all = [
+        "@platforms//os:qnx",
+        ":without_shm",
+    ]
 )
 
 filegroup(
@@ -38,7 +85,6 @@ cache_entries = {
     "ENABLE_LIFESPAN": "ON",
     "ENABLE_NETWORK_PARTITIONS": "ON",
     "ENABLE_SECURITY": "OFF",
-    "ENABLE_SOURCE_SPECIFIC_MULTICAST": "ON",
     "ENABLE_SSL": "OFF",  # TODO(mvukov) Here we could use openssl/boringssl.
     "ENABLE_TOPIC_DISCOVERY": "OFF",
     "ENABLE_TYPE_DISCOVERY": "OFF",
@@ -47,27 +93,56 @@ cache_entries = {
     "WITH_LWIP": "OFF",
 }
 
+cache_entries_linux_and_macos = {
+    "ENABLE_SOURCE_SPECIFIC_MULTICAST": "ON",
+}
+
+cache_entries_qnx = {
+    "ENABLE_SOURCE_SPECIFIC_MULTICAST": "OFF",
+    "ENABLE_IPV6": "OFF",
+    "CMAKE_SYSTEM_NAME": "QNX",
+}
+
+cache_entries_with_shm = {
+    "ENABLE_SHM": "ON",
+    "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/iceoryx",
+}
+
+cache_entries_without_shm = {
+    "ENABLE_SHM": "OFF",
+}
+
 cmake(
     name = "cyclonedds",
     build_args = [
         "--",
         "-j4",
     ],
-    cache_entries = select({
-        ":enable_shm_on": dicts.add(
-            cache_entries,
-            {
-                "ENABLE_SHM": "ON",
-                "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/iceoryx",
-            },
-        ),
-        "//conditions:default": dicts.add(
-            cache_entries,
-            {
-                "ENABLE_SHM": "OFF",
-            },
-        ),
-    }),
+    cache_entries = select(
+        {
+            ":linux_or_macos_with_shm": dicts.add(
+                cache_entries,
+                cache_entries_linux_and_macos,
+                cache_entries_with_shm
+            ),
+            ":qnx_with_shm": dicts.add(
+                cache_entries,
+                cache_entries_qnx,
+                cache_entries_with_shm
+            ),
+            ":linux_or_macos_without_shm": dicts.add(
+                cache_entries,
+                cache_entries_linux_and_macos,
+                cache_entries_without_shm
+            ),
+            ":qnx_without_shm": dicts.add(
+                cache_entries,
+                cache_entries_qnx,
+                cache_entries_without_shm
+            ),
+        },
+        no_match_error = "Unsupported build configuration",
+    ),
     generate_args = ["-GNinja"],
     lib_source = ":all_srcs",
     linkopts = select(
@@ -81,7 +156,7 @@ cmake(
     out_static_libs = ["libddsc.a"],
     visibility = ["//visibility:public"],
     deps = select({
-        ":enable_shm_on": ["@iceoryx"],
+        ":with_shm": ["@iceoryx"],
         "//conditions:default": [],
     }),
 )

--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -28,7 +28,7 @@ selects.config_setting_group(
     match_any = [
         "@platforms//os:linux",
         "@platforms//os:macos",
-    ]
+    ],
 )
 
 selects.config_setting_group(
@@ -36,7 +36,7 @@ selects.config_setting_group(
     match_all = [
         ":linux_or_macos",
         ":enable_shm_on",
-    ]
+    ],
 )
 
 selects.config_setting_group(
@@ -44,7 +44,7 @@ selects.config_setting_group(
     match_all = [
         "@platforms//os:qnx",
         ":enable_shm_on",
-    ]
+    ],
 )
 
 selects.config_setting_group(
@@ -52,7 +52,7 @@ selects.config_setting_group(
     match_all = [
         ":linux_or_macos",
         ":enable_shm_off",
-    ]
+    ],
 )
 
 selects.config_setting_group(
@@ -60,7 +60,7 @@ selects.config_setting_group(
     match_all = [
         "@platforms//os:qnx",
         ":enable_shm_off",
-    ]
+    ],
 )
 
 filegroup(
@@ -123,22 +123,22 @@ cmake(
             ":linux_or_macos_with_shm": dicts.add(
                 cache_entries,
                 cache_entries_linux_and_macos,
-                cache_entries_with_shm
+                cache_entries_with_shm,
             ),
             ":qnx_with_shm": dicts.add(
                 cache_entries,
                 cache_entries_qnx,
-                cache_entries_with_shm
+                cache_entries_with_shm,
             ),
             ":linux_or_macos_without_shm": dicts.add(
                 cache_entries,
                 cache_entries_linux_and_macos,
-                cache_entries_without_shm
+                cache_entries_without_shm,
             ),
             ":qnx_without_shm": dicts.add(
                 cache_entries,
                 cache_entries_qnx,
-                cache_entries_without_shm
+                cache_entries_without_shm,
             ),
         },
         no_match_error = "Unsupported build configuration",


### PR DESCRIPTION
In QNX pthread is bundled with libc.

My full patch actually looks like this:
```patch
diff --git a/BUILD.bazel b/BUILD.bazel
old mode 100755
new mode 100644
index 1d33e9b..f0047f9
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,7 @@ filegroup(
 
 cache_entries = {
     "CMAKE_BUILD_TYPE": "Release",
+    "CMAKE_SYSTEM_NAME": "Foo",
     "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
     "BUILD_SHARED_LIBS": "OFF",
     # CycloneDDS specific options.
@@ -38,7 +39,8 @@ cache_entries = {
     "ENABLE_LIFESPAN": "ON",
     "ENABLE_NETWORK_PARTITIONS": "ON",
     "ENABLE_SECURITY": "OFF",
-    "ENABLE_SOURCE_SPECIFIC_MULTICAST": "ON",
+    "ENABLE_SOURCE_SPECIFIC_MULTICAST": "OFF",
+    "ENABLE_IPV6": "OFF",
     "ENABLE_SSL": "OFF",  # TODO(mvukov) Here we could use openssl/boringssl.
     "ENABLE_TOPIC_DISCOVERY": "OFF",
     "ENABLE_TYPE_DISCOVERY": "OFF",
@@ -70,7 +72,14 @@ cmake(
     }),
     generate_args = ["-GNinja"],
     lib_source = ":all_srcs",
-    linkopts = ["-lpthread"],
+    linkopts = select(
+        {
+            "@platforms//os:linux": ["-lpthread"],
+            "@platforms//os:macos": ["-lpthread"],
+            "@platforms//os:qnx": [],
+        },
+        no_match_error = "Only Linux, macOS and QNX are supported!",
+    ),
     out_static_libs = ["libddsc.a"],
     visibility = ["//visibility:public"],
     deps = select({

```

But I'm not sure if this is acceptable upstream.