### PR TITLE
Enable building iceoryx for QNX

### DIFF
--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 filegroup(

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -29,11 +29,10 @@ cmake(
     cache_entries = selects.with_or(
         {
             ("@platforms//os:linux", "@platforms//os:macos"): cache_entries,
-            "@platforms//os:qnx":
-                dicts.add(
-                    cache_entries,
-                    cache_entries_qnx,
-                ),
+            "@platforms//os:qnx": dicts.add(
+                cache_entries,
+                cache_entries_qnx,
+            ),
         },
         no_match_error = "Only Linux, macOS and QNX are supported!",
     ),

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 filegroup(
@@ -7,6 +9,16 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+cache_entries = {
+    "BUILD_SHARED_LIBS": "OFF",
+    "CCACHE": "OFF",
+    "CMAKE_BUILD_TYPE": "Release",
+}
+
+cache_entries_qnx = {
+    "CMAKE_SYSTEM_NAME": "QNX",
+}
+
 # Depends on libacl. On Ubuntu install as `sudo apt-get install libacl1-dev`.
 cmake(
     name = "iceoryx",
@@ -14,19 +26,31 @@ cmake(
         "--",  # <- Pass options to the native tool.
         "-j4",
     ],
-    cache_entries = {
-        "BUILD_SHARED_LIBS": "OFF",
-        "CCACHE": "OFF",
-        "CMAKE_BUILD_TYPE": "Release",
-    },
+    cache_entries = selects.with_or(
+        {
+            ("@platforms//os:linux", "@platforms//os:macos"): cache_entries,
+            "@platforms//os:qnx":
+                dicts.add(
+                    cache_entries,
+                    cache_entries_qnx,
+                ),
+        },
+        no_match_error = "Only Linux, macOS and QNX are supported!",
+    ),
     generate_args = ["-GNinja"],
     lib_source = ":all_srcs",
-    linkopts = [
-        "-lacl",
-        "-latomic",
-        "-lpthread",
-        "-lrt",
-    ],
+    linkopts = selects.with_or(
+        {
+            ("@platforms//os:linux", "@platforms//os:macos"): [
+                "-lacl",
+                "-latomic",
+                "-lpthread",
+                "-lrt",
+            ],
+            "@platforms//os:qnx": ["-latomic"],
+        },
+        no_match_error = "Only Linux, macOS and QNX are supported!",
+    ),
     out_binaries = ["iox-roudi"],
     out_data_dirs = ["lib/cmake"],
     out_include_dir = "include/iceoryx/v2.0.2/",


### PR DESCRIPTION
acl, rt and pthread are part of libc. At the same time we need to tell the iceoryx build system that we are building for QNX so that it doesn't try to use Linux-specific headers.