### PR TITLE
Add Python bindings to tf2_msgs

### DIFF
--- a/repositories/geometry2.BUILD.bazel
+++ b/repositories/geometry2.BUILD.bazel
@@ -6,6 +6,7 @@ load(
 load(
     "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
     "cpp_ros2_interface_library",
+    "py_ros2_interface_library",
     "ros2_interface_library",
 )
 
@@ -27,6 +28,14 @@ ros2_interface_library(
 
 cpp_ros2_interface_library(
     name = "cpp_tf2_msgs",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tf2_msgs",
+    ],
+)
+
+py_ros2_interface_library(
+    name = "py_tf2_msgs",
     visibility = ["//visibility:public"],
     deps = [
         ":tf2_msgs",


### PR DESCRIPTION
Python bindings are missing for `tf2_msgs`.