### PR TITLE
Do not rely on `external` symlink for RMW_LIBRARY_PATH

### DIFF
--- a/repositories/rmw_implementation.BUILD.bazel
+++ b/repositories/rmw_implementation.BUILD.bazel
@@ -16,7 +16,7 @@ ros2_cpp_library(
     ],
     includes = ["include"],
     local_defines = [
-        "RMW_LIBRARY_PATH=\\\"external/ros2_rmw_cyclonedds/librmw_cyclonedds.so\\\"",
+        "RMW_LIBRARY_PATH=\\\"../ros2_rmw_cyclonedds/librmw_cyclonedds.so\\\"",
     ],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
We use a different relative path to librmw_cyclonedds.so to be compatible with Bazel's `--nolegacy_external_runfiles` option. Since we depend on the respective target, it can still be found in the runfiles tree, only in a different place.

Fixes #64