### PR TITLE
Fix Bazel repo name for eigen build_file

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -136,7 +136,7 @@ def ros2_repositories():
     maybe(
         http_archive,
         name = "eigen",
-        build_file = "@com_github_mvukov_rules_ros//repositories:eigen.BUILD.bazel",
+        build_file = "@com_github_mvukov_rules_ros2//repositories:eigen.BUILD.bazel",
         sha256 = "8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
         strip_prefix = "eigen-3.4.0",
         urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"],


### PR DESCRIPTION
Introduced in https://github.com/mvukov/rules_ros2/pull/70