### PR TITLE
Make image_transport_plugins cpp lib visible

### DIFF
--- a/repositories/image_common.BUILD.bazel
+++ b/repositories/image_common.BUILD.bazel
@@ -1,16 +1,5 @@
-load(
-    "@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl",
-    "ros2_cpp_library",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
-    "cpp_ros2_interface_library",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:plugin.bzl",
-    "ros2_plugin",
-)
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
+load("@com_github_mvukov_rules_ros2//ros2:plugin.bzl", "ros2_plugin")
 
 ros2_cpp_library(
     name = "camera_calibration_parsers",
@@ -123,6 +112,7 @@ ros2_plugin(
             "base_class_type": "image_transport::SubscriberPlugin",
         },
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":image_transport_common",
         "@ros2_common_interfaces//:cpp_sensor_msgs",

--- a/ros2/plugin.bzl
+++ b/ros2/plugin.bzl
@@ -15,20 +15,7 @@
 """
 
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
-load(
-    "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
-    "CppGeneratorAspectInfo",
-    "IdlAdapterAspectInfo",
-    "Ros2InterfaceInfo",
-    "cpp_generator_aspect",
-    "idl_adapter_aspect",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:plugin_aspects.bzl",
-    "Ros2PluginInfo",
-    "create_dynamic_library",
-)
-load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@com_github_mvukov_rules_ros2//ros2:plugin_aspects.bzl", "Ros2PluginInfo", "create_dynamic_library")
 
 def _ros2_plugin_impl(ctx):
     target_name = ctx.attr.name
@@ -78,7 +65,7 @@ def ros2_plugin(name, plugin_specs, **kwargs):
         base_class_type = plugin_spec["base_class_type"]
         types_to_bases_and_names[class_type] = [base_class_type, class_name]
 
-    lib_name = "_" + name
+    lib_name = "cpp_" + name
     tags = kwargs.pop("tags", None)
     visibility = kwargs.pop("visibility", None)
     ros2_cpp_library(
@@ -86,6 +73,7 @@ def ros2_plugin(name, plugin_specs, **kwargs):
         # This must be set such that static plugin registration works.
         alwayslink = True,
         tags = ["manual"],
+        visibility = visibility,
         **kwargs
     )
     ros2_plugin_rule(


### PR DESCRIPTION
Maybe I don't quite understand how the `ros2_plugin` rule is supposed to be used?

I was able to get my node running with the changes in this PR, and then adding `@ros2_image_common//:cpp_image_transport_plugins` as `deps` entry to my `ros2_cpp_binary`.

I also tried to add `@ros2_image_common//:image_transport_plugins` as a `data` dep, but that did not help and I continued to get the error below.


`[ERROR] [1678215815.321719302] [VideoDecoderNode]: Failed to load plugin image_transport/raw_pub, error string: MultiLibraryClassLoader: Could not create object of class type image_transport::RawPublisher as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()`

Buildifier also removed some load statements and I simplified the rest, I hope you don't mind.