### PR TITLE
Experiment: Make image_transport_plugins_tests work with clang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,4 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
-build --linkopt=-fuse-ld=/usr/lib/llvm-11/bin/lld
+# build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,3 +24,6 @@ test --build_tests_only
 # as the user configuration should be able to overwrite flags from this file.
 # See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
 try-import %workspace%/user.bazelrc
+
+build --repo_env=CC=clang
+build --repo_env=CXX=clang++

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
+build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,4 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
-build --linkopt=-fuse-ld=/usr/bin/ld.lld
+build --linkopt=-fuse-ld=/usr/lib/llvm-11/bin/lld

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,4 +27,5 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
+build --linkopt=-latomic # Clang builds need this to avoid "undefined symbol: __atomic_is_lock_free"
 # build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -27,4 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
-build --linkopt=-fuse-ld=/usr/lib/llvm-11/bin/lld
+# build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -24,3 +24,6 @@ test --build_tests_only
 # as the user configuration should be able to overwrite flags from this file.
 # See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
 try-import %workspace%/user.bazelrc
+
+build --repo_env=CC=clang
+build --repo_env=CXX=clang++

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -27,4 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
-build --linkopt=-fuse-ld=/usr/bin/ld.lld
+build --linkopt=-fuse-ld=/usr/lib/llvm-11/bin/lld

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -27,4 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
-build --linkopt=-B/usr/bin/ld.lld
+build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -27,3 +27,4 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
+build --linkopt=-B/usr/bin/ld.lld

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -27,4 +27,5 @@ try-import %workspace%/user.bazelrc
 
 build --repo_env=CC=clang
 build --repo_env=CXX=clang++
+build --linkopt=-latomic # Clang builds need this to avoid "undefined symbol: __atomic_is_lock_free"
 # build --linkopt=-fuse-ld=/usr/bin/ld.lld

--- a/repositories/image_common.BUILD.bazel
+++ b/repositories/image_common.BUILD.bazel
@@ -1,16 +1,5 @@
-load(
-    "@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl",
-    "ros2_cpp_library",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
-    "cpp_ros2_interface_library",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:plugin.bzl",
-    "ros2_plugin",
-)
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
+load("@com_github_mvukov_rules_ros2//ros2:plugin.bzl", "ros2_plugin")
 
 ros2_cpp_library(
     name = "camera_calibration_parsers",
@@ -123,6 +112,7 @@ ros2_plugin(
             "base_class_type": "image_transport::SubscriberPlugin",
         },
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":image_transport_common",
         "@ros2_common_interfaces//:cpp_sensor_msgs",

--- a/ros2/plugin.bzl
+++ b/ros2/plugin.bzl
@@ -15,20 +15,7 @@
 """
 
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
-load(
-    "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
-    "CppGeneratorAspectInfo",
-    "IdlAdapterAspectInfo",
-    "Ros2InterfaceInfo",
-    "cpp_generator_aspect",
-    "idl_adapter_aspect",
-)
-load(
-    "@com_github_mvukov_rules_ros2//ros2:plugin_aspects.bzl",
-    "Ros2PluginInfo",
-    "create_dynamic_library",
-)
-load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@com_github_mvukov_rules_ros2//ros2:plugin_aspects.bzl", "Ros2PluginInfo", "create_dynamic_library")
 
 def _ros2_plugin_impl(ctx):
     target_name = ctx.attr.name
@@ -78,7 +65,7 @@ def ros2_plugin(name, plugin_specs, **kwargs):
         base_class_type = plugin_spec["base_class_type"]
         types_to_bases_and_names[class_type] = [base_class_type, class_name]
 
-    lib_name = "_" + name
+    lib_name = "cpp_" + name
     tags = kwargs.pop("tags", None)
     visibility = kwargs.pop("visibility", None)
     ros2_cpp_library(
@@ -86,6 +73,7 @@ def ros2_plugin(name, plugin_specs, **kwargs):
         # This must be set such that static plugin registration works.
         alwayslink = True,
         tags = ["manual"],
+        visibility = visibility,
         **kwargs
     )
     ros2_plugin_rule(

--- a/ros2/test/image_common/BUILD.bazel
+++ b/ros2/test/image_common/BUILD.bazel
@@ -7,6 +7,7 @@ ros2_cpp_test(
     set_up_ament = True,
     deps = [
         "@com_google_googletest//:gtest_main",
+        "@ros2_image_common//:cpp_image_transport_plugins",
         "@ros2_image_common//:image_transport",
         "@ros2_pluginlib//:pluginlib",
     ],


### PR DESCRIPTION
`❯ bazel test //ros2/test/image_common:image_transport_plugins_tests`

`C++ exception with description "MultiLibraryClassLoader: Could not create object of class type image_transport::RawSubscriber as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()" thrown in the test body.`

<details><summary>Full log, failing test</summary>

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //ros2/test/image_common:image_transport_plugins_tests
-----------------------------------------------------------------------------
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from TestImageTransportPlugins
[ RUN      ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsurePublisherPluginCanBeLoaded
unknown file: Failure
C++ exception with description "MultiLibraryClassLoader: Could not create object of class type image_transport::RawPublisher as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()" thrown in the test body.
[  FAILED  ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsurePublisherPluginCanBeLoaded (10 ms)
[ RUN      ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsureSubscriberPluginCanBeLoaded
unknown file: Failure
C++ exception with description "MultiLibraryClassLoader: Could not create object of class type image_transport::RawSubscriber as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()" thrown in the test body.
[  FAILED  ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsureSubscriberPluginCanBeLoaded (10 ms)
[----------] 2 tests from TestImageTransportPlugins (20 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (20 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsurePublisherPluginCanBeLoaded
[  FAILED  ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsureSubscriberPluginCanBeLoaded

 2 FAILED TESTS
```

</details>


<details><summary>Full log, fixed test</summary>

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //ros2/test/image_common:image_transport_plugins_tests
-----------------------------------------------------------------------------
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from TestImageTransportPlugins
[ RUN      ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsurePublisherPluginCanBeLoaded
[       OK ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsurePublisherPluginCanBeLoaded (11 ms)
[ RUN      ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsureSubscriberPluginCanBeLoaded
[       OK ] TestImageTransportPlugins.WhenRawPluginsAvailable_EnsureSubscriberPluginCanBeLoaded (0 ms)
[----------] 2 tests from TestImageTransportPlugins (11 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (11 ms total)
[  PASSED  ] 2 tests.
```

</details>