### PR TITLE
Use bag split as signal from recorder in rosbag tests

### DIFF
--- a/ros2/test/rosbag/publisher.cc
+++ b/ros2/test/rosbag/publisher.cc
@@ -24,16 +24,20 @@ class Publisher : public rclcpp::Node {
     publisher_ = create_publisher<std_msgs::msg::String>("topic", 10);
     auto timer_callback = [this]() -> void {
       auto message = std_msgs::msg::String();
-      message.data = std::to_string(count_++);
+      // Produce reasonably large messages so we quickly reach the size limit
+      // that causes the recorder to split the bag (we use this as a signal that
+      // the recorder has received a sufficient number of messages).
+      constexpr std::size_t minimum_message_size = 8192;
+      constexpr char random_char = 'x';
+      message.data = std::string(minimum_message_size, random_char);
       publisher_->publish(message);
     };
     timer_ = create_wall_timer(std::chrono::milliseconds(20), timer_callback);
   }
 
  private:
-  rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
-  size_t count_ = 0;
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 int main(int argc, char* argv[]) {

--- a/ros2/test/rosbag/publisher.cc
+++ b/ros2/test/rosbag/publisher.cc
@@ -27,9 +27,8 @@ class Publisher : public rclcpp::Node {
       // Produce reasonably large messages so we quickly reach the size limit
       // that causes the recorder to split the bag (we use this as a signal that
       // the recorder has received a sufficient number of messages).
-      constexpr std::size_t minimum_message_size = 8192;
-      constexpr char random_char = 'x';
-      message.data = std::string(minimum_message_size, random_char);
+      constexpr std::size_t kMinimumMessageSize = 8192;
+      message.data = std::string(kMinimumMessageSize, 'x');
       publisher_->publish(message);
     };
     timer_ = create_wall_timer(std::chrono::milliseconds(20), timer_callback);

--- a/ros2/test/rosbag/recorder.cc
+++ b/ros2/test/rosbag/recorder.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "rosbag2_transport/recorder.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rosbag2_interfaces/msg/write_split_event.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
 #include "rosbag2_transport/record_options.hpp"
@@ -20,27 +21,27 @@
 
 constexpr auto kTopicName = "topic";
 
-class MessageCounter : public rclcpp::Node {
+class BagSplitEventListener : public rclcpp::Node {
  public:
-  MessageCounter() : Node("message_counter") {
-    subscription_ = create_subscription<std_msgs::msg::String>(
-        kTopicName, 10,
-        [this](std_msgs::msg::String::SharedPtr /*msg*/) { ++msg_count_; });
+  using MessageT = rosbag2_interfaces::msg::WriteSplitEvent;
+
+  BagSplitEventListener() : Node("bag_split_event_listener") {
+    subscription_ = create_subscription<MessageT>(
+        "events/write_split", 10,
+        [this](MessageT::SharedPtr /*msg*/) { ++split_count_; });
   }
 
-  auto msg_count() const { return msg_count_; }
+  auto split_count() const { return split_count_; }
 
  private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
-  int msg_count_ = 0;
+  rclcpp::Subscription<MessageT>::SharedPtr subscription_;
+  int split_count_ = 0;
 };
 
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  auto msg_counter = std::make_shared<MessageCounter>();
-  executor.add_node(msg_counter);
 
   rosbag2_transport::RecordOptions record_options;
   record_options.topics = {kTopicName};
@@ -54,19 +55,22 @@ int main(int argc, char* argv[]) {
       rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
 
   rosbag2_storage::StorageOptions storage_options;
-  storage_options.uri =
-      std::string(std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) + "/bag";
+  storage_options.uri = std::string(std::getenv("TEST_TMPDIR")) + "/bag";
   storage_options.storage_id = std::getenv("STORAGE_ID");
+  // we use the bag split event as a signal that we can stop
+  constexpr uint64_t sqlite3_minimum_split_size = 86016;
+  storage_options.max_bagfile_size = sqlite3_minimum_split_size;
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
       std::move(writer), storage_options, record_options);
-  recorder->record();
   executor.add_node(recorder);
 
-  while (rclcpp::ok()) {
+  auto split_counter = std::make_shared<BagSplitEventListener>();
+  executor.add_node(split_counter);
+
+  recorder->record();
+
+  while (rclcpp::ok() && split_counter->split_count() == 0) {
     executor.spin_once(std::chrono::milliseconds(10));
-    if (msg_counter->msg_count() > 10) {
-      break;
-    }
   }
 
   return rclcpp::shutdown() ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/ros2/test/rosbag/recorder.cc
+++ b/ros2/test/rosbag/recorder.cc
@@ -23,18 +23,18 @@ constexpr auto kTopicName = "topic";
 
 class BagSplitEventListener : public rclcpp::Node {
  public:
-  using MessageT = rosbag2_interfaces::msg::WriteSplitEvent;
+  using WriteSplitEvent = rosbag2_interfaces::msg::WriteSplitEvent;
 
   BagSplitEventListener() : Node("bag_split_event_listener") {
-    subscription_ = create_subscription<MessageT>(
+    subscription_ = create_subscription<WriteSplitEvent>(
         "events/write_split", 10,
-        [this](MessageT::SharedPtr /*msg*/) { ++split_count_; });
+        [this](WriteSplitEvent::SharedPtr /*msg*/) { ++split_count_; });
   }
 
   auto split_count() const { return split_count_; }
 
  private:
-  rclcpp::Subscription<MessageT>::SharedPtr subscription_;
+  rclcpp::Subscription<WriteSplitEvent>::SharedPtr subscription_;
   int split_count_ = 0;
 };
 
@@ -57,9 +57,9 @@ int main(int argc, char* argv[]) {
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = std::string(std::getenv("TEST_TMPDIR")) + "/bag";
   storage_options.storage_id = std::getenv("STORAGE_ID");
-  // we use the bag split event as a signal that we can stop
-  constexpr uint64_t sqlite3_minimum_split_size = 86016;
-  storage_options.max_bagfile_size = sqlite3_minimum_split_size;
+  // We use the bag split event as a signal that we can stop.
+  constexpr uint64_t kSqlite3MinimumSplitSize = 86016;
+  storage_options.max_bagfile_size = kSqlite3MinimumSplitSize;
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
       std::move(writer), storage_options, record_options);
   executor.add_node(recorder);

--- a/ros2/test/rosbag/tests.py
+++ b/ros2/test/rosbag/tests.py
@@ -61,7 +61,7 @@ class TestRecorder(unittest.TestCase):
             proc_info,
             allowable_exit_codes=[launch_testing.asserts.EXIT_OK],
             process=recorder)
-        bag_dir = os.path.join(os.environ['TEST_UNDECLARED_OUTPUTS_DIR'], 'bag')
+        bag_dir = os.path.join(os.environ['TEST_TMPDIR'], 'bag')
         bag_db_file = os.path.join(bag_dir,
                                    STORAGE_IDS_TO_BAG_NAMES[get_storage_id()])
         bag_metadata_file = os.path.join(bag_dir, 'metadata.yaml')


### PR DESCRIPTION
The rosbag tests are flaky, because it can happen that the recorder is
stopped before it has the required number of messages received. This is
because the process that contains the recorder has a second subscriber
that keeps track of the number of messages published. However, the
recorder's subscriber and that counting subscriber are not synchronized.
Even if the message counting subscriber has received some number of
messages, this doesn't mean that the recorder's subscriber has received
even a single message.

We fix the issue by replacing the message counting subscriber by one
that listens for bag split events. We also configure the recorder to
split bags once some number of bytes has been recorded. Once the bag
split event is received, we can be certain that the recorder has
received that amount of bytes.

Fixes #82.