### PR TITLE
Make builtin ros2_plugin targets visibile

### DIFF
--- a/repositories/image_common.BUILD.bazel
+++ b/repositories/image_common.BUILD.bazel
@@ -123,6 +123,7 @@ ros2_plugin(
             "base_class_type": "image_transport::SubscriberPlugin",
         },
     ],
+    visibility = ["//visibility:public"],  # https://github.com/mvukov/rules_ros2/issues/78
     deps = [
         ":image_transport_common",
         "@ros2_common_interfaces//:cpp_sensor_msgs",

--- a/repositories/rosbag2.BUILD.bazel
+++ b/repositories/rosbag2.BUILD.bazel
@@ -47,6 +47,7 @@ ros2_plugin(
             "base_class_type": "rosbag2_storage::storage_interfaces::ReadWriteInterface",
         },
     ],
+    visibility = ["//visibility:public"],  # https://github.com/mvukov/rules_ros2/issues/78
     deps = [
         ":rosbag2_storage",
         "@ros2_pluginlib//:pluginlib",
@@ -90,6 +91,7 @@ ros2_plugin(
             "base_class_type": "rosbag2_storage::storage_interfaces::ReadWriteInterface",
         },
     ],
+    visibility = ["//visibility:public"],  # https://github.com/mvukov/rules_ros2/issues/78
     deps = [
         ":mcap_vendor",
         ":rosbag2_storage",
@@ -182,6 +184,7 @@ ros2_plugin(
             "base_class_type": "rosbag2_compression::BaseDecompressorInterface",
         },
     ],
+    visibility = ["//visibility:public"],  # https://github.com/mvukov/rules_ros2/issues/78
     deps = [
         ":rosbag2_compression",
         "@ros2_pluginlib//:pluginlib",


### PR DESCRIPTION
There are some visbility issues on current main:
`ERROR: /home/user/repo/pkg/BUILD:229:16: in cc_binary rule //pkg:VideoDecoderNode: target '@ros2_image_common//:image_transport_plugins_impl' is not visible from target '//pkg:VideoDecoderNode'. Check the visibility declaration of the former target if you think the dependency is legitimate
ERROR: /home/user/repo/pkg/talos_video/BUILD:229:16: Analysis of target '//pkg:VideoDecoderNode' failed`

This is a follow-up fix to https://github.com/mvukov/rules_ros2/pull/86

Needed for the clangd workaround in https://github.com/mvukov/rules_ros2/issues/78
