### PR TITLE
Add ros2_node cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available features:
   - Zero copy transport via shared memory backend ([iceoryx](https://github.com/eclipse-iceoryx/iceoryx)) for CycloneDDS.
 - Utilities:
   - `ros2_bag` for handling rosbags
+  - `ros2_node` for handling nodes
   - `ros2_param` for handling parameters
   - `ros2_service` for handling services
   - `ros2_topic` for handling topics

--- a/ros2/BUILD.bazel
+++ b/ros2/BUILD.bazel
@@ -33,6 +33,16 @@ py_library(
 )
 
 py_binary(
+    name = "ros2_node",
+    srcs = ["ros2_node.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ros2_cmd",
+        "@ros2cli//:ros2node",
+    ],
+)
+
+py_binary(
     name = "ros2_param",
     srcs = ["ros2_param.py"],
     visibility = ["//visibility:public"],

--- a/ros2/ros2_node.py
+++ b/ros2/ros2_node.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Laurenz Altenmueller
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+
+import ros2cli.cli
+import ros2node.verb.info
+import ros2node.verb.list
+
+import ros2.ros2_cmd
+
+COMMAND_EXTENSIONS = {
+    'info': ros2node.verb.info.InfoVerb(),
+    'list': ros2node.verb.list.ListVerb(),
+}
+
+extension = ros2.ros2_cmd.Ros2CommandExtension(COMMAND_EXTENSIONS)
+sys.exit(ros2cli.cli.main(argv=sys.argv[1:], extension=extension))


### PR DESCRIPTION
```
❯ bazel run @com_github_mvukov_rules_ros2//ros2:ros2_node
INFO: Invocation ID: 4c89ed83-fd67-40a8-bd11-eadbc1da9736
INFO: Analyzed target @com_github_mvukov_rules_ros2//ros2:ros2_node (1 packages loaded, 12 targets configured).
INFO: Found 1 target...
Target @com_github_mvukov_rules_ros2//ros2:ros2_node up-to-date:
  bazel-bin/external/com_github_mvukov_rules_ros2/ros2/ros2_node
INFO: Elapsed time: 0.288s, Critical Path: 0.11s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/external/com_github_mvukov_rules_ros2/ros2/ros2_node
usage: ros2_node.py [-h] [--use-python-default-buffering] [--include-hidden-topics] Call `ros2 <command> -h` for more detailed usage. ...

ros2 is an extensible command-line tool for ROS 2.

optional arguments:
  -h, --help            show this help message and exit
  --use-python-default-buffering
                        Do not force line buffering in stdout and instead use the python default buffering, which might be affected by PYTHONUNBUFFERED/-u and depends on whatever
                        stdout is interactive or not
  --include-hidden-topics
                        Consider hidden topics as well

Commands:
  info  Output information about a node
  list  Output a list of available nodes

  Call `ros2 <command> -h` for more detailed usage.
```