### PR TITLE
Default `set_up_ament` to `True` for `ros2_cpp_test`, `ros2_py_test`

### DIFF
--- a/ros2/cc_defs.bzl
+++ b/ros2/cc_defs.bzl
@@ -109,12 +109,13 @@ def ros2_cpp_binary(name, ros2_package_name = None, set_up_ament = False, **kwar
         name: A unique target name.
         ros2_package_name: If given, defines a ROS package name for the target.
             Otherwise, the `name` is used as the package name.
-        set_up_ament: If true, sets up ament file tree for the binary target.
+        set_up_ament: If true, wrap the binary target to set up ament file tree and
+            missing ROS_HOME/ROS_LOG_DIR env vars.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
     """
     _ros2_cpp_exec(cc_binary, name, ros2_package_name, set_up_ament, **kwargs)
 
-def ros2_cpp_test(name, ros2_package_name = None, set_up_ament = False, **kwargs):
+def ros2_cpp_test(name, ros2_package_name = None, set_up_ament = True, **kwargs):
     """ Defines a ROS 2 C++ test.
 
     Adds common ROS 2 C++ definitions on top of a cc_test.
@@ -123,7 +124,8 @@ def ros2_cpp_test(name, ros2_package_name = None, set_up_ament = False, **kwargs
         name: A unique target name.
         ros2_package_name: If given, defines a ROS package name for the target.
             Otherwise, the `name` is used as the package name.
-        set_up_ament: If true, sets up ament file tree for the test target.
+        set_up_ament: If true, wrap the test target to set up ament file tree and
+            missing ROS_HOME/ROS_LOG_DIR env vars.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-tests
     """
     _ros2_cpp_exec(cc_test, name, ros2_package_name, set_up_ament, **kwargs)

--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -56,19 +56,21 @@ def ros2_py_binary(name, srcs, main, set_up_ament = False, **kwargs):
         name: A unique target name.
         srcs: List of source files.
         main: Source file to use as entrypoint.
-        set_up_ament: If true, sets up ament file tree for the binary target.
+        set_up_ament: If true, wrap the binary target to set up ament file tree and
+            missing ROS_HOME/ROS_LOG_DIR env vars.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
     """
     _ros2_py_exec(py_binary, name, srcs, main, set_up_ament, **kwargs)
 
-def ros2_py_test(name, srcs, main, set_up_ament = False, **kwargs):
+def ros2_py_test(name, srcs, main, set_up_ament = True, **kwargs):
     """ Defines a ROS 2 Python test.
 
     Args:
         name: A unique target name.
         srcs: List of source files.
         main: Source file to use as entrypoint.
-        set_up_ament: If true, sets up ament file tree for the test target.
+        set_up_ament: If true, wrap the test target to set up ament file tree and
+            missing ROS_HOME/ROS_LOG_DIR env vars.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-tests
     """
     _ros2_py_exec(py_test, name, srcs, main, set_up_ament, **kwargs)

--- a/ros2/test/BUILD.bazel
+++ b/ros2/test/BUILD.bazel
@@ -51,6 +51,5 @@ ros2_cpp_test(
     name = "test_rclcpp",
     size = "small",
     srcs = ["test_rclcpp.cpp"],
-    set_up_ament = True,
     deps = ["@ros2_rclcpp//:rclcpp"],
 )

--- a/ros2/test/launch_pytest/BUILD.bazel
+++ b/ros2/test/launch_pytest/BUILD.bazel
@@ -39,7 +39,6 @@ ros2_py_test(
     size = "small",
     srcs = ["rclpy_init_test.py"],
     main = "rclpy_init_test.py",
-    set_up_ament = True,
     deps = [
         "@ros2_launch//:launch_pytest",
         "@ros2_rclpy//:rclpy",


### PR DESCRIPTION
I believe this is a reasonable default because it shouldn't affect the observable behavior of existing tests, but will save new users from some debugging when they try to figure out what is causing the `rcutils_expand_user failed`, `Failed to get logging directory` errors in their tests that spin up the RCL.