### PR TITLE
Also allow `timeout` attribute in ros2_py_test, ros2_cpp_test

### DIFF
--- a/ros2/cc_defs.bzl
+++ b/ros2/cc_defs.bzl
@@ -73,6 +73,7 @@ def _ros2_cpp_exec(target, name, ros2_package_name = None, set_up_ament = False,
     tags = kwargs.pop("tags", [])
     visibility = kwargs.pop("visibility", None)
     size = kwargs.pop("size", None)
+    timeout = kwargs.pop("timeout", None)
     _ros2_cc_target(cc_binary, "cpp", target_impl, ros2_package_name, tags = ["manual"], **kwargs)
 
     is_test = target == cc_test
@@ -94,6 +95,7 @@ def _ros2_cpp_exec(target, name, ros2_package_name = None, set_up_ament = False,
     sh_target(
         name = name,
         size = size,
+        timeout = timeout,
         srcs = [launcher],
         data = [target_impl],
         tags = tags,

--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -14,6 +14,7 @@ def _ros2_py_exec(target, name, srcs, main, set_up_ament, **kwargs):
     tags = kwargs.pop("tags", [])
     visibility = kwargs.pop("visibility", None)
     size = kwargs.pop("size", None)
+    timeout = kwargs.pop("timeout", None)
     target(name = target_impl, srcs = srcs, main = main, tags = ["manual"], **kwargs)
 
     is_test = target == py_test
@@ -43,6 +44,7 @@ def _ros2_py_exec(target, name, srcs, main, set_up_ament, **kwargs):
     sh_target(
         name = name,
         size = size,
+        timeout = timeout,
         srcs = [launcher],
         data = [target_impl_symlink],
         tags = tags,


### PR DESCRIPTION
Forgot about that one. Without this, I'm getting
```
ERROR: /home/user/repo/pkg/BUILD:30:14: //pkg:target: no such attribute 'timeout' in 'cc_binary' rule
WARNING: Target pattern parsing failed.
```