### PR TITLE
Add patch to move ts_lib to PublisherBase

### DIFF
--- a/repositories/patches/rclcpp_move_ts_lib_to_publisher_base.patch
+++ b/repositories/patches/rclcpp_move_ts_lib_to_publisher_base.patch
@@ -1,0 +1,78 @@
+diff --git a/rclcpp/include/rclcpp/generic_publisher.hpp b/rclcpp/include/rclcpp/generic_publisher.hpp
+index e1b46002..a58b1c94 100644
+--- a/rclcpp/include/rclcpp/generic_publisher.hpp
++++ b/rclcpp/include/rclcpp/generic_publisher.hpp
+@@ -78,8 +78,8 @@ public:
+       node_base,
+       topic_name,
+       *rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
+-      options.template to_rcl_publisher_options<rclcpp::SerializedMessage>(qos)),
+-    ts_lib_(ts_lib)
++      options.template to_rcl_publisher_options<rclcpp::SerializedMessage>(qos),
++      ts_lib)
+   {
+     // This is unfortunately duplicated with the code in publisher.hpp.
+     // TODO(nnmm): Deduplicate by moving this into PublisherBase.
+@@ -128,9 +128,6 @@ public:
+   void publish_as_loaned_msg(const rclcpp::SerializedMessage & message);
+ 
+ private:
+-  // The type support library should stay loaded, so it is stored in the GenericPublisher
+-  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
+-
+   void * borrow_loaned_message();
+   void deserialize_message(
+     const rmw_serialized_message_t & serialized_message,
+diff --git a/rclcpp/include/rclcpp/publisher_base.hpp b/rclcpp/include/rclcpp/publisher_base.hpp
+index 8416757a..44633d08 100644
+--- a/rclcpp/include/rclcpp/publisher_base.hpp
++++ b/rclcpp/include/rclcpp/publisher_base.hpp
+@@ -36,6 +36,7 @@
+ #include "rclcpp/qos_event.hpp"
+ #include "rclcpp/type_support_decl.hpp"
+ #include "rclcpp/visibility_control.hpp"
++#include "rcpputils/shared_library.hpp"
+ #include "rcpputils/time.hpp"
+ 
+ namespace rclcpp
+@@ -78,7 +79,8 @@ public:
+     rclcpp::node_interfaces::NodeBaseInterface * node_base,
+     const std::string & topic,
+     const rosidl_message_type_support_t & type_support,
+-    const rcl_publisher_options_t & publisher_options);
++    const rcl_publisher_options_t & publisher_options,
++    std::shared_ptr<rcpputils::SharedLibrary> ts_lib = {});
+ 
+   RCLCPP_PUBLIC
+   virtual ~PublisherBase();
+@@ -313,6 +315,10 @@ public:
+     event_handlers_[event_type]->clear_on_ready_callback();
+   }
+ 
++private:
++  // The type support library should stay loaded, so it is stored in the GenericPublisher
++  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
++
+ protected:
+   template<typename EventCallbackT>
+   void
+diff --git a/rclcpp/src/rclcpp/publisher_base.cpp b/rclcpp/src/rclcpp/publisher_base.cpp
+index 723d56e0..6ea8ec34 100644
+--- a/rclcpp/src/rclcpp/publisher_base.cpp
++++ b/rclcpp/src/rclcpp/publisher_base.cpp
+@@ -45,11 +45,13 @@ PublisherBase::PublisherBase(
+   rclcpp::node_interfaces::NodeBaseInterface * node_base,
+   const std::string & topic,
+   const rosidl_message_type_support_t & type_support,
+-  const rcl_publisher_options_t & publisher_options)
++  const rcl_publisher_options_t & publisher_options,
++  std::shared_ptr<rcpputils::SharedLibrary> ts_lib)
+ : rcl_node_handle_(node_base->get_shared_rcl_node_handle()),
+   intra_process_is_enabled_(false),
+   intra_process_publisher_id_(0),
+-  type_support_(type_support)
++  type_support_(type_support),
++  ts_lib_(std::move(ts_lib))
+ {
+   auto custom_deleter = [node_handle = this->rcl_node_handle_](rcl_publisher_t * rcl_pub)
+     {

--- a/repositories/ros2_repo_mappings.yaml
+++ b/repositories/ros2_repo_mappings.yaml
@@ -69,6 +69,7 @@ repositories:
       - "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_fix-maybe-uninitialized-warning.patch"
       # https://github.com/mvukov/rules_ros2/pull/47
       - "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_move_ts_lib_to_subscription_base.patch"
+      - "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_move_ts_lib_to_publisher_base.patch"
   rclpy:
     name: ros2_rclpy
     build_file: "@com_github_mvukov_rules_ros2//repositories:rclpy.BUILD.bazel"

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -173,7 +173,7 @@ def ros2_repositories_impl():
         build_file = "@com_github_mvukov_rules_ros2//repositories:rclcpp.BUILD.bazel",
         patch_cmds = ["patch"],
         patch_args = ["-p1"],
-        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_fix-maybe-uninitialized-warning.patch", "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_move_ts_lib_to_subscription_base.patch"],
+        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_fix-maybe-uninitialized-warning.patch", "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_move_ts_lib_to_subscription_base.patch", "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_move_ts_lib_to_publisher_base.patch"],
         sha256 = "50bf8b420c502571aba792f4bce9d9521404e4d15dfff352ce242a205e31caad",
         strip_prefix = "rclcpp-16.0.4",
         url = "https://github.com/ros2/rclcpp/archive/refs/tags/16.0.4.tar.gz",

--- a/ros2/test/rosbag/BUILD.bazel
+++ b/ros2/test/rosbag/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_github_mvukov_rules_ros2//ros2:bag.bzl", "ros2_bag")
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_binary")
 load("@com_github_mvukov_rules_ros2//ros2:py_defs.bzl", "ros2_py_test")
 load("@com_github_mvukov_rules_ros2//ros2:test.bzl", "ros2_test")
@@ -23,10 +24,22 @@ ros2_cpp_binary(
     ],
 )
 
+ros2_bag(
+    name = "bag",
+    idl_deps = [
+        "@ros2_common_interfaces//:std_msgs",
+        "@ros2_rcl_interfaces//:rcl_interfaces",
+        "@ros2_rosbag2//:rosbag2_interfaces",
+    ],
+)
+
 [
     ros2_test(
         name = "{}_tests".format(storage_id),
         size = "small",
+        data = [
+            ":bag",
+        ],
         env = {
             "STORAGE_ID": storage_id,
         },


### PR DESCRIPTION
This adds a patch that moves the `std::shared_ptr` holding a reference to a `rclcpp::SharedLibrary` from `rclcpp::GenericPublisher` to `rclcpp::PublisherBase`. The shared library in question contains type support code for the publisher's message type. In the standard ROS build, two separate shared objects are used, one is represented by the mentioned `shared_ptr`-wrapped `SharedLibrary` instance, the other is never unloaded. At the same time, code from the latter library is required during destruction of a `PublisherBase` instance. The rules_ros2 build creates a single library, which is unloaded when `GenericPublisher` is destroyed (the `shared_ptr`'s reference count goes to zero). When `GenericPublisher`'s parent class, `PublisherBase`, is destroyed, trying to call code from the shared library failed and caused a segfault. Moving the `shared_ptr` to `PublisherBase` makes sure the shared library stays loaded as long as required.

We further extend the existing rosbag test to also excersise the `play` command.

This fix is similar to what was done for PR#47. See the discussion there for more details.

Fixes #110