### PR TITLE
Fix gtest fetch issue

### DIFF
--- a/repositories/patches/gtest_fix_fetch.patch
+++ b/repositories/patches/gtest_fix_fetch.patch
@@ -1,0 +1,27 @@
+--- BUILD.bazel	2023-05-26 17:34:36.407802028 +0200
++++ BUILD.bazel	2023-05-26 17:35:10.456190917 +0200
+@@ -130,23 +130,6 @@
+         ],
+         "//conditions:default": ["-pthread"],
+     }),
+-    deps = select({
+-        ":has_absl": [
+-            "@com_google_absl//absl/debugging:failure_signal_handler",
+-            "@com_google_absl//absl/debugging:stacktrace",
+-            "@com_google_absl//absl/debugging:symbolize",
+-            "@com_google_absl//absl/flags:flag",
+-            "@com_google_absl//absl/flags:parse",
+-            "@com_google_absl//absl/flags:reflection",
+-            "@com_google_absl//absl/flags:usage",
+-            "@com_google_absl//absl/strings",
+-            "@com_google_absl//absl/types:any",
+-            "@com_google_absl//absl/types:optional",
+-            "@com_google_absl//absl/types:variant",
+-            "@com_googlesource_code_re2//:re2",
+-        ],
+-        "//conditions:default": [],
+-    }),
+ )
+
+ cc_library(
+

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -77,6 +77,7 @@ def ros2_repositories():
         sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
         strip_prefix = "googletest-release-1.12.1",
         url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:gtest_fix_fetch.patch"],
     )
 
     maybe(

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -62,7 +62,7 @@ def ros2_repositories_impl():
     maybe(
         http_archive,
         name = "iceoryx",
-        strip_prefix = "iceoryx-2.0.2",
+        strip_prefix = "iceoryx-2.0.3",
         build_file = "@com_github_mvukov_rules_ros2//repositories:iceoryx.BUILD.bazel",
         sha256 = "8f391696daf2e63da9437aab8d7154371df630fc93876479f2e84c693fc1ba5a",
         url = "https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.3.tar.gz",


### PR DESCRIPTION
bazel fetch errors can also cause issues with bazel queries and bazel fetch can detect dependency changes if run in CI.