### PR TITLE
Allow empty nodes list for launch file

### DIFF
--- a/ros2/launch.bzl
+++ b/ros2/launch.bzl
@@ -4,22 +4,24 @@
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "py_launcher")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-def ros2_launch(name, nodes, launch_file, deps = None, data = None, idl_deps = None, **kwargs):
+def ros2_launch(name, launch_file, nodes = None, deps = None, data = None, idl_deps = None, **kwargs):
     """ Defines a ROS 2 deployment.
 
     Args:
         name: A unique target name.
-        nodes: A list of ROS 2 nodes for the deployment.
         launch_file: A ros2launch-compatible launch file.
+        nodes: A list of ROS 2 nodes for the deployment.
         deps: Additional Python deps that can be used by the launch file.
         data: Additional data that can be used by the launch file.
         idl_deps: Additional IDL deps that are used as runtime plugins.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
     """
     launcher = "{}_launch".format(name)
+    nodes = nodes or []
+    deps = deps or []
     launch_script = py_launcher(
         launcher,
-        deps = nodes + (deps or []),
+        deps = nodes + deps,
         idl_deps = idl_deps,
         template = "@com_github_mvukov_rules_ros2//ros2:launch.py.tpl",
         substitutions = {
@@ -30,7 +32,6 @@ def ros2_launch(name, nodes, launch_file, deps = None, data = None, idl_deps = N
     )
 
     data = data or []
-    deps = deps or []
     py_binary(
         name = name,
         srcs = [launcher],

--- a/ros2/launch.bzl
+++ b/ros2/launch.bzl
@@ -16,9 +16,6 @@ def ros2_launch(name, nodes, launch_file, deps = None, data = None, idl_deps = N
         idl_deps: Additional IDL deps that are used as runtime plugins.
         **kwargs: https://bazel.build/reference/be/common-definitions#common-attributes-binaries
     """
-    if not nodes:
-        fail("A list of nodes must be given!")
-
     launcher = "{}_launch".format(name)
     launch_script = py_launcher(
         launcher,


### PR DESCRIPTION
I have some launch files that don't directly depend on any binaries. Instead they (conditionally) include some other launch files. These should go into the ros2_launch deps I'd say.
Unfortunately currently empty nodes lists are not allowed. I don't think this restriction is necessary and can be simply removed.

Since it's a positional arg if you don't specify `nodes` Bazel will already fail with `Error: ros2_launch() missing 1 required positional argument: nodes`. I think no further check is necessary.