### PR TITLE
Support cross compilation to aarch64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,10 @@ build:clang --repo_env=CC=clang
 build:clang --repo_env=CXX=clang++
 build:clang --linkopt="-fuse-ld=lld"
 
+# To cross-compile towards aarch64, invoke Bazel with `--config=aarch64_linux_gcc`.
+build:platform_build --incompatible_enable_cc_toolchain_resolution
+build:aarch64_linux_gcc --config=platform_build --platforms=@aspect_gcc_toolchain//platforms:aarch64_linux
+
 # Load any settings specific to the current user.
 # user.bazelrc should appear in .gitignore so that settings are not shared with
 # team members. This needs to be last statement in this config,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,3 +46,31 @@ load(
 )
 
 install_rules_ros2_resolver_deps()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "aspect_gcc_toolchain",
+    sha256 = "8850373f24d3f8bb6e8f36e3e8e7edc93d948964f8f201e920af2c8ffba2002c",
+    strip_prefix = "gcc-toolchain-4bd1f94536ee92b7c49673931773038d923ee86e",
+    url = "https://github.com/aspect-build/gcc-toolchain/archive/4bd1f94536ee92b7c49673931773038d923ee86e.tar.gz",
+)
+
+load("@aspect_gcc_toolchain//toolchain:repositories.bzl", "gcc_toolchain_dependencies")
+
+gcc_toolchain_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+
+aspect_bazel_lib_dependencies()
+
+load("@aspect_gcc_toolchain//toolchain:defs.bzl", "ARCHS", "gcc_register_toolchain")
+
+gcc_register_toolchain(
+    name = "gcc_toolchain_aarch64",
+    target_arch = ARCHS.aarch64,
+)

--- a/repositories/openssl.BUILD.bazel
+++ b/repositories/openssl.BUILD.bazel
@@ -1,4 +1,39 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+# support cross-compilation
+# otherwise openssl will configure towards the host system
+selects.config_setting_group(
+    name = "linux_aarch64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_x86_64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "macos_x86_64",
+    match_all = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "macos_aarch64",
+    match_all = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+)
 
 filegroup(
     name = "all_srcs",
@@ -17,11 +52,17 @@ filegroup(
 configure_make(
     name = "openssl",
     args = ["-j4"],
-    configure_command = "config",
+    configure_command = "Configure",
     configure_options = [
         "no-shared",
         "--libdir=lib",
-    ],
+    ] + select({
+        ":linux_x86_64": ["linux-x86_64"],
+        ":linux_aarch64": ["linux-aarch64"],
+        ":macos_x86_64": ["darwin64-x86_64-cc"],
+        ":macos_aarch64": ["darwin64-arm64-cc"],
+        "//conditions:default":  [],
+    }),
     lib_source = ":all_srcs",
     linkopts = ["-ldl"],
     out_static_libs = [

--- a/repositories/patches/cyclonedds_remove_flto.patch
+++ b/repositories/patches/cyclonedds_remove_flto.patch
@@ -1,0 +1,27 @@
+diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
+index a4bd15ef..f68174f2 100644
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -28,14 +28,14 @@ if(ENABLE_SSL AND OPENSSL_FOUND)
+   endif()
+ endif()
+ 
+-include(CheckIPOSupported)
+-check_ipo_supported(RESULT ipo_supported OUTPUT error)
+-if(ipo_supported)
+-  set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+-  set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE)
+-  #-flto and debugging info do not seem to go well together
+-  #set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
+-endif()
++#include(CheckIPOSupported)
++#check_ipo_supported(RESULT ipo_supported OUTPUT error)
++#if(ipo_supported)
++#  set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
++#  set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE)
++#  #-flto and debugging info do not seem to go well together
++#  #set_property(TARGET ddsc PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
++#endif()
+ 
+ # Support the OMG DDS Security within ddsc adds quite a bit of code.
+ if(ENABLE_SECURITY)

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -290,6 +290,8 @@ def ros2_repositories():
         urls = ["https://github.com/ros/diagnostics/archive/9f402787ea2c9b3dd4d7e51a9986810e8a3400ba.zip"],
     )
 
+
+
 def _googletest_deps():
     """Lists implicit googletest deps.
 

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -43,6 +43,8 @@ def ros2_repositories_impl():
         http_archive,
         name = "cyclonedds",
         build_file = "@com_github_mvukov_rules_ros2//repositories:cyclonedds.BUILD.bazel",
+        patch_args = ["-p1"],
+        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:cyclonedds_remove_flto.patch"],
         sha256 = "b2ae16fa6a1812e453f5bf31e4dcb7ce263e486279c0530565a33a49c71c74b8",
         strip_prefix = "cyclonedds-0.9.1",
         url = "https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.9.1.tar.gz",


### PR DESCRIPTION
Solving the issue discussed here: https://github.com/mvukov/rules_ros2/issues/144

I also implemented a feature to cross compile towards aarch64
See https://github.com/mvukov/rules_ros2/discussions/150 for more info.

- Patch cyclonedds to remove -flto
- Added gcc_toolchain and openssl cross compile support for aarch64