### PR TITLE
removed all occurences of CMAKE_BUILD_TYPE

### DIFF
--- a/repositories/curl.BUILD.bazel
+++ b/repositories/curl.BUILD.bazel
@@ -16,7 +16,6 @@ cmake(
         "-j4",
     ],
     cache_entries = {
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
         "BUILD_SHARED_LIBS": "OFF",
         # curl specific options.

--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -70,7 +70,6 @@ filegroup(
 )
 
 cache_entries = {
-    "CMAKE_BUILD_TYPE": "Release",
     "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
     "BUILD_SHARED_LIBS": "OFF",
     # CycloneDDS specific options.

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -12,7 +12,6 @@ filegroup(
 cache_entries = {
     "BUILD_SHARED_LIBS": "OFF",
     "CCACHE": "OFF",
-    "CMAKE_BUILD_TYPE": "Release",
 }
 
 cache_entries_qnx = {

--- a/repositories/yaml_cpp.BUILD.bazel
+++ b/repositories/yaml_cpp.BUILD.bazel
@@ -17,7 +17,6 @@ cmake(
     ],
     cache_entries = {
         "BUILD_SHARED_LIBS": "OFF",
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
         "YAML_CPP_BUILD_CONTRIB": "ON",
         "YAML_CPP_BUILD_TESTS": "OFF",

--- a/repositories/zstd.BUILD.bazel
+++ b/repositories/zstd.BUILD.bazel
@@ -16,7 +16,6 @@ cmake(
         "-j4",
     ],
     cache_entries = {
-        "CMAKE_BUILD_TYPE": "Release",
         "ZSTD_BUILD_PROGRAMS": "OFF",
         "ZSTD_BUILD_SHARED": "OFF",
         "ZSTD_BUILD_STATIC": "ON",


### PR DESCRIPTION
See this discussion: https://github.com/mvukov/rules_ros2/discussions/154

CMAKE_BUILD_TYPE is handled internally in foreign_rules_cc:
https://github.com/bazelbuild/rules_foreign_cc/blob/816905a078773405803e86635def78b61d2f782d/foreign_cc/cmake.bzl#L208

Use `--compilation_mode=dbg` build flag to set `CMAKE_BUILD_TYPE=Debug` this also sets the other required flags for the cc compiler. `CMAKE_BUILD_TYPE=Release` is the default.