### PR TITLE
Fix/spdlog bundled fmt

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,7 @@
         "pybind11",
         "rules_foreign_cc",
         "rules_python",
+        "spdlog",
         "tinyxml2",
         "websocketpp",
         "zstd",

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,6 @@
         "foxglove_bridge",
         "nlohmann_json",
         "pybind11",
-        "spdlog",
         "rules_foreign_cc",
         "rules_python",
         "tinyxml2",

--- a/repositories/fmt.BUILD.bazel
+++ b/repositories/fmt.BUILD.bazel
@@ -6,7 +6,10 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "fmt",
-    srcs = glob(["src/**/*.cc"]),
+    srcs = glob(
+        ["src/**/*.cc"],
+        exclude = ["src/fmt.cc"],
+    ),
     hdrs = glob(["include/**/*.h"]),
     copts = CPP_COPTS + ["-w"],
     includes = ["include"],

--- a/repositories/fmt.BUILD.bazel
+++ b/repositories/fmt.BUILD.bazel
@@ -1,0 +1,14 @@
+""" Builds fmt
+"""
+
+load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "CPP_COPTS")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "fmt",
+    srcs = glob(["src/**/*.cc"]),
+    hdrs = glob(["include/**/*.h"]),
+    copts = CPP_COPTS + ["-w"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -29,11 +29,20 @@ def ros2_repositories():
 
     maybe(
         http_archive,
+        name = "fmt",
+        build_file = "@com_github_mvukov_rules_ros2//repositories:fmt.BUILD.bazel",
+        sha256 = "5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc",
+        strip_prefix = "fmt-7.1.3",
+        url = "https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz",
+    )
+
+    maybe(
+        http_archive,
         name = "spdlog",
         build_file = "@com_github_mvukov_rules_ros2//repositories:spdlog.BUILD.bazel",
-        sha256 = "4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9",
-        strip_prefix = "spdlog-1.12.0",
-        url = "https://github.com/gabime/spdlog/archive/v1.12.0.tar.gz",
+        sha256 = "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8",
+        strip_prefix = "spdlog-1.8.5",
+        url = "https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz",
     )
 
     maybe(

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -31,18 +31,18 @@ def ros2_repositories():
         http_archive,
         name = "fmt",
         build_file = "@com_github_mvukov_rules_ros2//repositories:fmt.BUILD.bazel",
-        sha256 = "5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc",
-        strip_prefix = "fmt-7.1.3",
-        url = "https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz",
+        sha256 = "5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2",
+        strip_prefix = "fmt-9.1.0",
+        url = "https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz",
     )
 
     maybe(
         http_archive,
         name = "spdlog",
         build_file = "@com_github_mvukov_rules_ros2//repositories:spdlog.BUILD.bazel",
-        sha256 = "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8",
-        strip_prefix = "spdlog-1.8.5",
-        url = "https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz",
+        sha256 = "4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9",
+        strip_prefix = "spdlog-1.12.0",
+        url = "https://github.com/gabime/spdlog/archive/v1.12.0.tar.gz",
     )
 
     maybe(

--- a/repositories/spdlog.BUILD.bazel
+++ b/repositories/spdlog.BUILD.bazel
@@ -4,13 +4,21 @@
 load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "CPP_COPTS")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-# NOTE: Uses fmt library bundled with spdlog.
 cc_library(
     name = "spdlog",
-    srcs = glob(["src/*.cpp"]),
-    hdrs = glob(["include/**/*.h"]),
-    copts = CPP_COPTS,
-    defines = ["SPDLOG_COMPILED_LIB"],
+    srcs = glob(
+        ["src/**/*.cpp"],
+        exclude = ["src/fmt.cpp"],
+    ) + ["include/spdlog/fmt/fmt.h"],
+    hdrs = glob(
+        ["include/**/*.h"],
+        exclude = ["include/spdlog/fmt/*.h"],
+    ),
+    copts = CPP_COPTS + ["-w"],
+    defines = [
+        "SPDLOG_COMPILED_LIB",
+        "SPDLOG_FMT_EXTERNAL",
+    ],
     includes = ["include"],
     linkopts = select(
         {
@@ -21,4 +29,5 @@ cc_library(
         no_match_error = "Only Linux, macOS and QNX are supported!",
     ),
     visibility = ["//visibility:public"],
+    deps = ["@fmt"],
 )

--- a/repositories/spdlog.BUILD.bazel
+++ b/repositories/spdlog.BUILD.bazel
@@ -12,7 +12,7 @@ cc_library(
     ) + ["include/spdlog/fmt/fmt.h"],
     hdrs = glob(
         ["include/**/*.h"],
-        exclude = ["include/spdlog/fmt/*.h"],
+        exclude = ["include/spdlog/fmt/bundled/*.h"],
     ),
     copts = CPP_COPTS + ["-w"],
     defines = [


### PR DESCRIPTION
Extra fmt-related headers are now included in 88850d799416c196fce9b38376cfe3029233dd1d. @henriksod Please test this with your work on micro-dds.