### PR TITLE
Use `exec` in launch wrapper

### DIFF
--- a/examples/lifecycle/BUILD.bazel
+++ b/examples/lifecycle/BUILD.bazel
@@ -5,6 +5,7 @@ load("@com_github_mvukov_rules_ros2//ros2:test.bzl", "ros2_test")
 ros2_cpp_binary(
     name = "lifecycle_talker",
     srcs = ["lifecycle_talker.cc"],
+    set_up_ament = True,
     deps = [
         "@ros2_common_interfaces//:cpp_std_msgs",
         "@ros2_rcl_interfaces//:cpp_lifecycle_msgs",

--- a/ros2/launch.sh.tpl
+++ b/ros2/launch.sh.tpl
@@ -15,7 +15,7 @@ fi
 ament_prefix_path="{{ament_prefix_path}}"
 if [ -z "${ament_prefix_path}" ]; then
   unset AMENT_PREFIX_PATH
-  {entry_point} "$@"
+  exec {entry_point} "$@"
 else
-  AMENT_PREFIX_PATH="${ament_prefix_path}" {entry_point} "$@"
+  AMENT_PREFIX_PATH="${ament_prefix_path}" exec {entry_point} "$@"
 fi


### PR DESCRIPTION
This adds `exec` to the call of the actual binary in the launch script template. This way, no new process is created for the actual binary, but it takes the place of the wrapper script (including its PID). Without this, ROS 2 launch cannot properly communicate with the binary, as it sends signals to the wrapper script, which by default doesn't forward signals to a child process (the binary in this case).