### PR TITLE
Add Python target for rosbag2_interfaces

### DIFF
--- a/repositories/rosbag2.BUILD.bazel
+++ b/repositories/rosbag2.BUILD.bazel
@@ -9,6 +9,7 @@ load(
 load(
     "@com_github_mvukov_rules_ros2//ros2:interfaces.bzl",
     "cpp_ros2_interface_library",
+    "py_ros2_interface_library",
     "ros2_interface_library",
 )
 load("@com_github_mvukov_rules_ros2//ros2:plugin.bzl", "ros2_plugin")
@@ -203,6 +204,13 @@ ros2_interface_library(
 
 cpp_ros2_interface_library(
     name = "cpp_rosbag2_interfaces",
+    visibility = ["//visibility:public"],
+    deps = [":rosbag2_interfaces"],
+)
+
+py_ros2_interface_library(
+    name = "py_rosbag2_interfaces",
+    visibility = ["//visibility:public"],
     deps = [":rosbag2_interfaces"],
 )
 


### PR DESCRIPTION
Also make libraries public. `rosbag2_interfaces` is public, so there's
no real reason why `{cpp,py}_rosbag2_interfaces` shouldn't be.