### PR TITLE
Add default python and node versions in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_language_version:
+  python: python3.10
+  node: 18.16.0
+
 default_stages: [commit]
 
 exclude: (.*\.patch)


### PR DESCRIPTION
This makes `pre-commit` run (again) on my machine.

Before that I got
```
ERROR: npm v9.6.6 is known not to run on Node.js v12.22.9.  This version of npm supports the following node versions: `^14.17.0 || ^16.13.0 || >=18.0.0`. You can find the latest version at https://nodejs.org/.
```
On a Ubuntu 22 machine.