### PR TITLE
Drop dependency on Boost

### DIFF
--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -2,7 +2,6 @@
 """
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 def ros2_deps():
@@ -10,5 +9,3 @@ def ros2_deps():
     """
     bazel_skylib_workspace()
     rules_foreign_cc_dependencies()
-
-    boost_deps()

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -291,14 +291,6 @@ def ros2_repositories():
 
     maybe(
         http_archive,
-        name = "com_github_nelhage_rules_boost",
-        sha256 = "b375550dde177abb48d9fc6edf63a7850aec350cdb4dc3360a456ea0fbd7d45c",
-        strip_prefix = "rules_boost-45015796689f17e9fc7972073eb7830784c40ee9",
-        urls = ["https://github.com/nelhage/rules_boost/archive/45015796689f17e9fc7972073eb7830784c40ee9.zip"],
-    )
-
-    maybe(
-        http_archive,
         name = "curl",
         build_file = "@com_github_mvukov_rules_ros2//repositories:curl.BUILD.bazel",
         sha256 = "230d61a4b1eb3346930f2d601cc8fe5237957163e16befbe15e0ef40c56767a2",

--- a/repositories/resource_retriever.BUILD.bazel
+++ b/repositories/resource_retriever.BUILD.bazel
@@ -10,7 +10,6 @@ cc_library(
     includes = ["resource_retriever/include"],
     visibility = ["//visibility:public"],
     deps = [
-        "@boost//:shared_ptr",
         "@curl",
         "@ros2_ament_index//:ament_index_cpp",
     ],


### PR DESCRIPTION
As pointed out in https://github.com/mvukov/rules_ros2/pull/238#issuecomment-1909969580, Boost is only needed for Foxglove. It turns out it isn't actually needed there either (anymore?).

In Foxglove itself, there is only a ROS 1 Smoketest that needs boost::filesystem. So nothing we need to care about. https://github.com/search?q=repo%3Afoxglove%2Fros-foxglove-bridge%20boost&type=code

In ROS 2's resource_retriever, It seems like there was some Boost going on in the past, but on the Humble branch there definitely isn't any: https://github.com/ros/resource_retriever/blob/humble/resource_retriever/include/resource_retriever/retriever.hpp

Unless I missed something it seems to be we can just drop the dependency on Boost altogether in rules_ros2.