### PR TITLE
refactor: Rename googletest and yaml-cpp to align with bzlmod versions

### DIFF
--- a/examples/zero_copy/BUILD.bazel
+++ b/examples/zero_copy/BUILD.bazel
@@ -79,7 +79,7 @@ ros2_cpp_binary(
     srcs = ["talker_tests.cc"],
     deps = [
         ":cpp_chatter_interface",
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@ros2_rclcpp//:rclcpp",
     ],
 )

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,7 @@
       matchManagers: ["bazel"],
       matchPackageNames: [
         "bazel_skylib",
-        "com_google_googletest",
+        "googletest",
         "eigen",
         "foxglove_bridge",
         "nlohmann_json",

--- a/repositories/image_common.BUILD.bazel
+++ b/repositories/image_common.BUILD.bazel
@@ -29,7 +29,7 @@ ros2_cpp_library(
         "@ros2_common_interfaces//:cpp_sensor_msgs",
         "@ros2_rclcpp//:rclcpp",
         "@ros2_rcpputils//:rcpputils",
-        "@yaml_cpp",
+        "@yaml-cpp",
     ],
 )
 

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -73,7 +73,7 @@ def ros2_repositories():
 
     maybe(
         http_archive,
-        name = "com_google_googletest",
+        name = "googletest",
         sha256 = "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7",
         strip_prefix = "googletest-1.14.0",
         url = "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz",
@@ -146,8 +146,8 @@ def ros2_repositories():
 
     maybe(
         http_archive,
-        name = "yaml_cpp",
-        build_file = "@com_github_mvukov_rules_ros2//repositories:yaml_cpp.BUILD.bazel",
+        name = "yaml-cpp",
+        build_file = "@com_github_mvukov_rules_ros2//repositories:yaml-cpp.BUILD.bazel",
         sha256 = "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3",
         strip_prefix = "yaml-cpp-yaml-cpp-0.7.0",
         urls = ["https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"],

--- a/repositories/rosbag2.BUILD.bazel
+++ b/repositories/rosbag2.BUILD.bazel
@@ -29,7 +29,7 @@ ros2_cpp_library(
         "@ros2_pluginlib//:pluginlib",
         "@ros2_rcpputils//:rcpputils",
         "@ros2_rcutils//:rcutils",
-        "@yaml_cpp",
+        "@yaml-cpp",
     ],
 )
 
@@ -54,7 +54,7 @@ ros2_plugin(
         "@ros2_rcpputils//:rcpputils",
         "@ros2_rcutils//:rcutils",
         "@sqlite",
-        "@yaml_cpp",
+        "@yaml-cpp",
     ],
 )
 
@@ -142,7 +142,7 @@ ros2_cpp_library(
         "@ros2_rosidl//:rosidl_runtime_cpp",
         "@ros2_rosidl//:rosidl_typesupport_introspection_cpp",
         "@ros2_rosidl_typesupport//:rosidl_typesupport_cpp",
-        "@yaml_cpp",
+        "@yaml-cpp",
     ],
 )
 
@@ -232,7 +232,7 @@ ros2_cpp_library(
         "@readerwriterqueue",
         "@ros2_keyboard_handler//:keyboard_handler",
         "@ros2_rmw//:rmw_cpp",
-        "@yaml_cpp",
+        "@yaml-cpp",
     ],
 )
 

--- a/repositories/yaml-cpp.BUILD.bazel
+++ b/repositories/yaml-cpp.BUILD.bazel
@@ -1,4 +1,4 @@
-""" Builds yaml_cpp.
+""" Builds yaml-cpp.
 """
 
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
@@ -10,7 +10,7 @@ filegroup(
 )
 
 cmake(
-    name = "yaml_cpp",
+    name = "yaml-cpp",
     build_args = [
         "--",
         "-j4",

--- a/ros2/test/BUILD.bazel
+++ b/ros2/test/BUILD.bazel
@@ -62,7 +62,7 @@ ros2_cpp_test(
         "@ros2_common_interfaces//:std_msgs",
     ],
     deps = [
-        "@com_google_googletest//:gtest",
+        "@googletest//:gtest",
         "@ros2_rclcpp//:rclcpp",
     ],
 )

--- a/ros2/test/image_common/BUILD.bazel
+++ b/ros2/test/image_common/BUILD.bazel
@@ -7,7 +7,7 @@ ros2_cpp_test(
     srcs = ["image_transport_plugins_tests.cc"],
     set_up_ament = True,
     deps = [
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest_main",
         "@ros2_image_common//:image_transport",
         "@ros2_pluginlib//:pluginlib",
     ],

--- a/ros2/test/pluginlib/BUILD.bazel
+++ b/ros2/test/pluginlib/BUILD.bazel
@@ -50,7 +50,7 @@ ros2_cpp_test(
     set_up_ament = True,
     deps = [
         ":polygon_base",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest_main",
         "@ros2_pluginlib//:pluginlib",
     ],
 )
@@ -91,7 +91,7 @@ ros2_cpp_binary(
     set_up_ament = True,
     deps = [
         ":polygon_base",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest_main",
         "@ros2_pluginlib//:pluginlib",
     ],
 )
@@ -152,7 +152,7 @@ cc_test(
         ":polygon_base",
         ":square_ament_setup",
         ":triangle_ament_setup",
-        "@com_google_googletest//:gtest_main",
+        "@googletest//:gtest_main",
         "@ros2_pluginlib//:pluginlib",
     ],
 )

--- a/third_party/foxglove_bridge/BUILD.bazel
+++ b/third_party/foxglove_bridge/BUILD.bazel
@@ -48,8 +48,8 @@ ros2_cpp_test(
     ],
     tags = ["cpu:2"],
     deps = [
-        "@com_google_googletest//:gtest",
         "@foxglove_bridge//:foxglove_bridge_component",
+        "@googletest//:gtest",
         "@ros2_common_interfaces//:cpp_std_msgs",
     ],
 )


### PR DESCRIPTION
Extracted from / in preparation for https://github.com/mvukov/rules_ros2/pull/238

No functional or version changes in this one.

If downstream consumers of rules_ros2 depend on com_google_googletest or yaml_cpp they need to either rename their deps or properly declare their dependencies instead of relying on rules_ros2's transitive deps.