### PR TITLE
Use rules_python `current_py_cc_headers`

### DIFF
--- a/repositories/geometry2.BUILD.bazel
+++ b/repositories/geometry2.BUILD.bazel
@@ -154,7 +154,7 @@ ros2_cpp_binary(
     linkshared = True,
     deps = [
         ":tf2",
-        "@rules_ros2_python//:python_headers",
+        "@rules_python//python/cc:current_py_cc_headers",
     ],
 )
 

--- a/repositories/pip_annotations.bzl
+++ b/repositories/pip_annotations.bzl
@@ -7,7 +7,7 @@ cc_library(
     name = "headers",
     hdrs = glob(["site-packages/numpy/core/include/numpy/**/*.h"]),
     includes = ["site-packages/numpy/core/include"],
-    deps = ["@rules_ros2_python//:python_headers"],
+    deps = ["@rules_python//python/cc:current_py_cc_headers"],
 )
 """,
     ),

--- a/repositories/pybind11.BUILD.bazel
+++ b/repositories/pybind11.BUILD.bazel
@@ -8,5 +8,5 @@ cc_library(
     hdrs = glob(["include/pybind11/**/*.h"]),
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = ["@rules_ros2_python//:python_headers"],
+    deps = ["@rules_python//python/cc:current_py_cc_headers"],
 )

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -821,7 +821,7 @@ py_generator_aspect = aspect(
         ),
         "_py_ext_c_deps": attr.label_list(
             default = [
-                Label("@rules_ros2_python//:python_headers"),
+                Label("@rules_python//python/cc:current_py_cc_headers"),
                 Label("@rules_ros2_pip_deps_numpy//:headers"),
             ],
             providers = [CcInfo],


### PR DESCRIPTION
`@rules_ros2_python//:python_headers` --> `@rules_python//python/cc:current_py_cc_headers`

Extracted from / in preparation for https://github.com/mvukov/rules_ros2/pull/238

Note that due to https://github.com/bazelbuild/rules_python/issues/1669 you need an up-to-date rules_python (>= 0.28.0) for this to work.

No functional or version changes in this one.