### PR TITLE
Make finding aggregator_node runfile bzlmod compatible

### DIFF
--- a/ros2/test/diagnostics/BUILD.bazel
+++ b/ros2/test/diagnostics/BUILD.bazel
@@ -24,5 +24,6 @@ ros2_test(
     deps = [
         "@ros2_common_interfaces//:py_diagnostic_msgs",
         "@ros2_rclpy//:rclpy",
+        "@rules_python//python/runfiles",
     ],
 )

--- a/ros2/test/diagnostics/tests.py
+++ b/ros2/test/diagnostics/tests.py
@@ -20,7 +20,11 @@ import launch_ros.actions
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
+import python.runfiles
 import rclpy
+
+AGGREGATOR_NODE_PATH = python.runfiles.Runfiles.Create().Rlocation(
+    'ros2_diagnostics/aggregator_node')
 
 
 @launch_testing.markers.keep_alive
@@ -32,7 +36,7 @@ def generate_test_description():
     )
 
     aggregator_node = launch_ros.actions.Node(
-        executable='../ros2_diagnostics/aggregator_node',
+        executable=AGGREGATOR_NODE_PATH,
         name='diagnostic_aggregator',
         parameters=['ros2/test/diagnostics/aggregator_config.yaml'],
     )


### PR DESCRIPTION
Extracted from / in preparation for https://github.com/mvukov/rules_ros2/pull/238

No functional or version changes in this one.