### PR TITLE
Actually cache stuff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,9 +87,10 @@ jobs:
         uses: actions/cache@v4.0.0
         with:
           path: |
+            ~/.cache/bazel
             ~/.cache/bazel-repo
-          key: v3-bazel-repo-cache-${{ hashFiles('.bazelversion', 'examples/WORKSPACE', 'repositories/**', 'requirements_lock.txt', 'WORKSPACE') }}
-          restore-keys: v3-bazel-repo-cache-
+          key: v3-bazel-repo-cache-${{ matrix.toolchain }}-${{ hashFiles('.bazelversion', 'examples/WORKSPACE', 'repositories/**', 'requirements_lock.txt', 'WORKSPACE') }}
+          restore-keys: v3-bazel-repo-cache-${{ matrix.toolchain }}-
       - name: bazel test ${{ matrix.config_option }} //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.


### PR DESCRIPTION
I checked with `bazel info` and CI's output base is definitely still in `~/.cache/bazel/`, so Bazel caching wasn't working for a while. It was removed in https://github.com/mvukov/rules_ros2/pull/33 -- I'm guessing by accident.

I also added the toolchain to the cache key to store the clang and gcc variants separately