### PR TITLE
Use bzlmod-compatible libyaml release

### DIFF
--- a/repositories/libyaml.BUILD.bazel
+++ b/repositories/libyaml.BUILD.bazel
@@ -1,26 +1,10 @@
 """ Builds libyaml.
 """
 
-load(
-    "@com_github_mvukov_rules_ros2//third_party:expand_template.bzl",
-    "expand_template",
-)
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-expand_template(
-    name = "config_h",
-    out = "include/config.h",
-    substitutions = {
-        "@YAML_VERSION_MAJOR@": "0",
-        "@YAML_VERSION_MINOR@": "2",
-        "@YAML_VERSION_PATCH@": "5",
-        "@YAML_VERSION_STRING@": "0.2.5",
-    },
-    template = "cmake/config.h.in",
-)
-
 cc_library(
-    name = "yaml",
+    name = "libyaml",
     srcs = [
         "src/api.c",
         "src/dumper.c",
@@ -31,10 +15,15 @@ cc_library(
         "src/scanner.c",
         "src/writer.c",
         "src/yaml_private.h",
-    ] + [":config_h"],
+    ],
     hdrs = ["include/yaml.h"],
     copts = ["-w"],
     includes = ["include"],
-    local_defines = ["HAVE_CONFIG_H"],
+    local_defines = [
+        "YAML_VERSION_MAJOR=0",
+        "YAML_VERSION_MINOR=2",
+        "YAML_VERSION_PATCH=5",
+        'YAML_VERSION_STRING=\\"0.2.5\\"',
+    ],
     visibility = ["//visibility:public"],
 )

--- a/repositories/rcl.BUILD.bazel
+++ b/repositories/rcl.BUILD.bazel
@@ -13,7 +13,7 @@ ros2_c_library(
     includes = ["rcl_yaml_param_parser/include"],
     visibility = ["//visibility:public"],
     deps = [
-        "@libyaml//:yaml",
+        "@libyaml",
         "@ros2_rcutils//:rcutils",
         "@ros2_rmw//:rmw",
     ],

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -49,9 +49,9 @@ def ros2_repositories():
         http_archive,
         name = "libyaml",
         build_file = "@com_github_mvukov_rules_ros2//repositories:libyaml.BUILD.bazel",
-        sha256 = "2c103fc473e904c6fe7580277f1fa16b6d716e54d5e3f32a8913c4850ae03b3f",
-        strip_prefix = "libyaml-acd6f6f014c25e46363e718381e0b35205df2d83",
-        urls = ["https://github.com/yaml/libyaml/archive/acd6f6f014c25e46363e718381e0b35205df2d83.tar.gz"],
+        sha256 = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
+        strip_prefix = "yaml-0.2.5",
+        urls = ["https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
libyaml was added to BCR in https://github.com/bazelbuild/bazel-central-registry/pull/1104

This PR is to update the current WORKSPACE version to use the same BUILD and target name.

The source URL also changed to the release artifact. The commit we're currently pointing at is literally the 0.2.5 tag, but the release artifact has a slightly different structure. That's why there is no expand_template anymore.