### PR TITLE
Refactor ssl lib name

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,7 +25,7 @@
         "eigen",
         "foxglove_bridge",
         "nlohmann_json",
-        "openssl",
+        "boringssl",
         "pybind11",
         "rules_foreign_cc",
         "rules_python",

--- a/repositories/asio.BUILD.bazel
+++ b/repositories/asio.BUILD.bazel
@@ -15,5 +15,5 @@ cc_library(
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = ["@openssl//:ssl"],
+    deps = ["@boringssl//:ssl"],
 )

--- a/repositories/curl.BUILD.bazel
+++ b/repositories/curl.BUILD.bazel
@@ -104,7 +104,7 @@ cp ${BUILD_TMPDIR}/lib/libcurl.a ${INSTALLDIR}/lib
     """,
     visibility = ["//visibility:public"],
     deps = [
-        "@openssl//:ssl",
+        "@boringssl//:ssl",
         "@zlib",
     ],
 )

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -222,7 +222,7 @@ def ros2_repositories():
     # support Bazel.
     maybe(
         http_archive,
-        name = "openssl",
+        name = "boringssl",
         sha256 = "0746b073903927720436c2041e4026761d40022fe24ea6d7d8674c9dac87054e",
         strip_prefix = "boringssl-ce71b7ff95ce43a3e64acded8535691ac141d5ad",
         urls = ["https://github.com/hedronvision/boringssl/archive/ce71b7ff95ce43a3e64acded8535691ac141d5ad.tar.gz"],


### PR DESCRIPTION
We're using BoringSSL, not OpenSSL. Need to update the lib name to be compatible with the BCR boringssl version.