### PR TITLE
Simplify CI setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,9 @@ build:clang --repo_env=CC=clang
 build:clang --repo_env=CXX=clang++
 build:clang --linkopt="-fuse-ld=lld"
 
+# Load --config=ci settings
+import %workspace%/ci.bazelrc
+
 # Load any settings specific to the current user.
 # user.bazelrc should appear in .gitignore so that settings are not shared with
 # team members. This needs to be last statement in this config,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,30 +72,14 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      # Cache build and external artifacts so that the next ci build is incremental.
-      # Because github action caches cannot be updated after a build, we need to
-      # store the contents of each build in a unique cache key, then fall back to loading
-      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
-      # the prefix to load the most recent cache for the branch on a cache miss. You
-      # should customize the contents of hashFiles to capture any bazel input sources,
-      # although this doesn't need to be perfect. If none of the input sources change
-      # then a cache hit will load an existing cache and bazel won't have to do any work.
-      # In the case of a cache miss, you want the fallback cache to contain most of the
-      # previously built artifacts to minimize build time. The more precise you are with
-      # hashFiles sources the less work bazel will have to do.
-      - name: Mount bazel caches
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
-          key: v3-bazel-repo-cache-${{ matrix.toolchain }}-${{ hashFiles('.bazelversion', 'examples/WORKSPACE', 'repositories/**', 'requirements_lock.txt', 'WORKSPACE') }}
-          restore-keys: v3-bazel-repo-cache-${{ matrix.toolchain }}-
-      - name: bazel test ${{ matrix.config_option }} //...
+
+      - name: bazel test //...
         env:
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
-          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           USER: ${{ needs.configure.outputs.user_name }}
         working-directory: ${{ matrix.folder }}
-        run: ${GITHUB_WORKSPACE}/.github/workflows/test.sh ${{ matrix.config_option }}
+        run: >
+          bazel test
+          --config=ci
+          --remote_header=x-buildbuddy-api-key="${{secrets.BUILDBUDDY_ORG_API_KEY}}"
+          ${{ matrix.config_option }}
+          //...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
     container:
       image: mvukov/bazel-builder:commit-8b1d07f800cc2b9a47a010da5b42c3f29294506e
       options: --user ${{ needs.configure.outputs.uid_gid }}
+    env:
+      BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
 
     # Run bazel test with gcc and clang in each workspace
     strategy:
@@ -73,13 +75,12 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
+      - name: Use BuildBuddy RW API key instead of public readonly key
+        run: sed -i.bak 's#x-buildbuddy-api-key=.*#x-buildbuddy-api-key=${{ env.BUILDBUDDY_ORG_API_KEY }}#' .bazelrc
+        if: ${{ env.BUILDBUDDY_ORG_API_KEY }}
+
       - name: bazel test //...
         env:
           USER: ${{ needs.configure.outputs.user_name }}
         working-directory: ${{ matrix.folder }}
-        run: >
-          bazel test
-          --config=ci
-          --remote_header=x-buildbuddy-api-key="${{secrets.BUILDBUDDY_ORG_API_KEY}}"
-          ${{ matrix.config_option }}
-          //...
+        run: bazel test --config=ci ${{ matrix.config_option }} //...

--- a/ci.bazelrc
+++ b/ci.bazelrc
@@ -2,11 +2,13 @@
 # It is referenced with a --bazelrc option in the call to bazel in main.yaml
 
 # Debug where options came from
-build --announce_rc
+build:ci --announce_rc
 # This directory is configured in GitHub actions to be persisted between runs.
-build --repository_cache=~/.cache/bazel-repo
+build:ci --repository_cache=~/.cache/bazel-repo
+
 
 # Set up remote cache.
+build:ci --config=remote
 build:remote --bes_results_url=https://app.buildbuddy.io/invocation/
 build:remote --bes_backend=grpcs://remote.buildbuddy.io
 build:remote --remote_cache=grpcs://remote.buildbuddy.io
@@ -21,10 +23,8 @@ build:remote --remote_build_event_upload=minimal
 build:remote --noslim_profile
 
 # Don't spam CI logs.
-build --show_progress_rate_limit=60
+build:ci --show_progress_rate_limit=60
 
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
-test --test_output=errors
-# Allows tests to run bazelisk-in-bazel, since this is the cache folder used
-test --test_env=XDG_CACHE_HOME
+test:ci --test_output=errors

--- a/ci.bazelrc
+++ b/ci.bazelrc
@@ -12,6 +12,7 @@ build:ci --config=remote
 build:remote --bes_results_url=https://app.buildbuddy.io/invocation/
 build:remote --bes_backend=grpcs://remote.buildbuddy.io
 build:remote --remote_cache=grpcs://remote.buildbuddy.io
+build:remote --remote_header=x-buildbuddy-api-key=TODO # Public readonly key # pragma: allowlist secret
 build:remote --remote_timeout=3600
 build:remote --remote_download_toplevel
 build:remote --experimental_remote_cache_compression

--- a/examples/ci.bazelrc
+++ b/examples/ci.bazelrc
@@ -1,0 +1,1 @@
+../ci.bazelrc


### PR DESCRIPTION
Let me know what you think about this one. I think having the actions/cache doesn't really make sense: It doesn't matter if a freshly spun up runner downloads the Bazel output base / Bazel action cache from GitHub's Cache or from BuildBuddy's Cache. In fact the action/cache will just blindly download the entire cache every time, even if the Bazel remote cache has all build and test results fully cached and nothing needs to be downloaded.
Same thinking for the Bazelisk caching. Doesn't matter if it's downloaded from the GH cache or from the Bazelisk download URL.

Additionally I cleaned up the CI test setup:
* Move ci.bazelrc to the repo root and symlink it in the same way as the .bazelrc in /examples.
* import the ci.bazelrc from .bazelrc, so there is no need to add --bazelrc options to the bazel invocation in CI
* Remove the test.sh and instead add --config=ci and the BB api key directly in the GHA yaml.

I believe a fully-cached build isn't possible in either case because of the many rules_foreign_cc CMake builds, which don't cache properly.

There is one gotcha: PRs from forks do not have access to the repo secrets, including the Buildbuddy api key. My suggestion is to create a [read-only key](https://www.buildbuddy.io/docs/guide-auth/#read-only-keys) at https://app.buildbuddy.io/settings/org/api-keys and then add that publicly visible in the .bazelrc (I put a TODO there as a placeholder for now). Builds will then use the read-only key by default. But in rules_ros2 repo GitHub Action runs it will replace the line in the .bazelrc the read/write key.