### PR TITLE
Fix stripped prefix of iceoryx

### DIFF
--- a/repositories/ros2_repo_mappings.yaml
+++ b/repositories/ros2_repo_mappings.yaml
@@ -24,7 +24,7 @@ repositories:
       - "@com_github_mvukov_rules_ros2//repositories/patches:geometry2_fix-use-after-free-bug.patch"
   iceoryx:
     name: iceoryx
-    strip_prefix: iceoryx-2.0.3
+    strip_prefix: iceoryx-2.0.5
     build_file: "@com_github_mvukov_rules_ros2//repositories:iceoryx.BUILD.bazel"
   image_common:
     name: ros2_image_common

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -62,7 +62,7 @@ def ros2_repositories_impl():
     maybe(
         http_archive,
         name = "iceoryx",
-        strip_prefix = "iceoryx-2.0.3",
+        strip_prefix = "iceoryx-2.0.5",
         build_file = "@com_github_mvukov_rules_ros2//repositories:iceoryx.BUILD.bazel",
         sha256 = "bf6de70e3edee71223f993a29bff5e61af95ce4871104929d8bd1729f544bafb",
         url = "https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.5.tar.gz",


### PR DESCRIPTION
Fix issue where `iceoryx` is being pulled down as version 2.0.5, but we are stripping 2.0.3, which causes build errors like `Prefix "iceoryx-2.0.3" was given, but not found in the archive. Here are possible prefixes for this archive: "iceoryx-2.0.5".`  This changed the version that is being stripped from 2.0.3 to 2.0.5.