### PR TITLE
Use our own Python for specific py_binaries and py_tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_ros2_pythons//3.10:defs.bzl", "compile_pip_requirements")
 
 compile_pip_requirements(
     name = "python_requirements",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,17 +10,17 @@ load("//repositories:deps.bzl", "ros2_deps")
 
 ros2_deps()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_multi_toolchains")
 
 py_repositories()
 
-python_register_toolchains(
-    name = "rules_ros2_python",
-    python_version = "3.10",
+python_register_multi_toolchains(
+    name = "rules_ros2_pythons",
+    python_versions = ["3.10"],
 )
 
 load("@rules_python//python:pip.bzl", "pip_parse")
-load("@rules_ros2_python//:defs.bzl", python_interpreter_target = "interpreter")
+load("@rules_ros2_pythons//3.10:defs.bzl", python_interpreter_target = "interpreter")
 load("//repositories:pip_annotations.bzl", "PIP_ANNOTATIONS")
 
 pip_parse(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -26,18 +26,18 @@ load("@com_github_mvukov_rules_ros2//repositories:deps.bzl", "ros2_deps")
 
 ros2_deps()
 
-load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_multi_toolchains")
 
 py_repositories()
 
-python_register_toolchains(
-    name = "rules_ros2_python",
-    python_version = "3.10",
+python_register_multi_toolchains(
+    name = "rules_ros2_pythons",
+    python_versions = ["3.10"],
 )
 
 load("@com_github_mvukov_rules_ros2//repositories:pip_annotations.bzl", "PIP_ANNOTATIONS")
 load("@rules_python//python:pip.bzl", "pip_parse")
-load("@rules_ros2_python//:defs.bzl", python_interpreter_target = "interpreter")
+load("@rules_ros2_pythons//3.10:defs.bzl", python_interpreter_target = "interpreter")
 
 pip_parse(
     name = "rules_ros2_pip_deps",

--- a/repositories/rclcpp.BUILD.bazel
+++ b/repositories/rclcpp.BUILD.bazel
@@ -10,8 +10,8 @@ load(
     "rclcpp_interfaces",
 )
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 _GENERATE_LOGGING_MACROS_PY = "@com_github_mvukov_rules_ros2//repositories:generate_rclcpp_logging_macros.py"
 

--- a/repositories/rcutils.BUILD.bazel
+++ b/repositories/rcutils.BUILD.bazel
@@ -7,8 +7,9 @@ load(
     "logging_macros",
 )
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_c_library")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 _GENERATE_LOGGING_MACROS_PY = "@com_github_mvukov_rules_ros2//repositories:generate_rcutils_logging_macros.py"
 

--- a/repositories/rosidl.BUILD.bazel
+++ b/repositories/rosidl.BUILD.bazel
@@ -9,8 +9,9 @@ load(
     "ros2_cpp_binary",
     "ros2_cpp_library",
 )
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 ros2_c_library(
     name = "rosidl_typesupport_interface",

--- a/repositories/rosidl_python.BUILD.bazel
+++ b/repositories/rosidl_python.BUILD.bazel
@@ -2,8 +2,9 @@
 """
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 py_library(
     name = "rosidl_generator_py_lib",

--- a/repositories/rosidl_typesupport.BUILD.bazel
+++ b/repositories/rosidl_typesupport.BUILD.bazel
@@ -7,7 +7,8 @@ load(
     "ros2_c_library",
     "ros2_cpp_library",
 )
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 ros2_c_library(
     name = "rosidl_typesupport_c_c",

--- a/repositories/xacro.BUILD.bazel
+++ b/repositories/xacro.BUILD.bazel
@@ -1,8 +1,9 @@
 """ Builds xacro.
 """
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 py_library(
     name = "xacro",

--- a/ros2/BUILD.bazel
+++ b/ros2/BUILD.bazel
@@ -1,7 +1,8 @@
 """ ROS 2 common definitions.
 """
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 exports_files([
     "ament.bzl",

--- a/ros2/bag.bzl
+++ b/ros2/bag.bzl
@@ -3,7 +3,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "py_launcher")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 def ros2_bag(name, idl_deps = None, **kwargs):
     """ Defines a binary target for a bag app.

--- a/ros2/launch.bzl
+++ b/ros2/launch.bzl
@@ -2,7 +2,7 @@
 """
 
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "py_launcher")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 def ros2_launch(name, launch_file, nodes = None, deps = None, data = None, idl_deps = None, **kwargs):
     """ Defines a ROS 2 deployment.

--- a/ros2/plugin_aspects.bzl
+++ b/ros2/plugin_aspects.bzl
@@ -38,15 +38,16 @@ Ros2PluginCollectorAspectInfo = provider(
     ],
 )
 
-_ROS2_COLLECTOR_ATTR_ASPECTS = ["data", "deps"]
+# From https://github.com/bazelbuild/rules_python/blob/0.33.2/python/config_settings/transition.bzl#L121-L140
+_py_transition_attrs = ["target", "tools"]
+
+_ROS2_COLLECTOR_ATTR_ASPECTS = ["data", "deps"] + _py_transition_attrs
 
 def _get_list_attr(rule_attr, attr_name):
-    if not hasattr(rule_attr, attr_name):
-        return []
-    candidate = getattr(rule_attr, attr_name)
-    if type(candidate) != "list":
-        fail("Expected a list for attribute `{}`!".format(attr_name))
-    return candidate
+    candidate = getattr(rule_attr, attr_name, [])
+    if type(candidate) == type([]):
+        return candidate
+    return [candidate]
 
 def _collect_deps(rule_attr, attr_name, provider_info):
     return [

--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -3,7 +3,7 @@
 
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "sh_launcher", "split_kwargs")
 load("@com_github_mvukov_rules_ros2//third_party:symlink.bzl", "symlink")
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary", "py_test")
 
 def _ros2_py_exec(target, name, srcs, main, set_up_ament, **kwargs):
     if set_up_ament == False:

--- a/ros2/service.bzl
+++ b/ros2/service.bzl
@@ -1,7 +1,7 @@
 """ Implements a macro for setting up a ROS 2 service app.
 """
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 def ros2_service(name, deps, **kwargs):
     """ Defines a ROS 2 service app for a set of deps.

--- a/ros2/test.bzl
+++ b/ros2/test.bzl
@@ -2,8 +2,8 @@
 """
 
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "py_launcher")
-load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_test")
 
 def ros2_test(name, launch_file, nodes = None, deps = None, data = None, idl_deps = None, use_pytest = False, **kwargs):
     """ Defines a ROS 2 test.

--- a/ros2/topic.bzl
+++ b/ros2/topic.bzl
@@ -1,7 +1,7 @@
 """ Implements a macro for setting up a ROS 2 topic app.
 """
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_ros2_pythons//3.10:defs.bzl", "py_binary")
 
 def ros2_topic(name, deps, **kwargs):
     """ Defines a ROS 2 topic app for a set of deps.


### PR DESCRIPTION
Split off https://github.com/mvukov/rules_ros2/pull/238

OK so this one is a slightly bigger change. What's happening is that it changes the rules_ros2 machinery to use its own bundled 3.10 interpreter. This way we can ensure that all the pip requirements we depend on will actually work.
The other reason for this change, including the funky `python_register_multi_toolchains` that registers only a single version, is that this makes it compatible to the Bzlmod way of pinning the interpreter like this.

See also https://rules-python.readthedocs.io/en/latest/toolchains.html#library-modules-with-version-constraints