### PR TITLE
fix CMAKE_SYSTEM_NAME for Android and QNX

### DIFF
--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -40,17 +40,17 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
-    name = "android_or_qnx",
-    match_any = [
+    name = "android_with_shm",
+    match_all = [
         "@platforms//os:android",
-        "@platforms//os:qnx",
+        ":enable_shm_on",
     ],
 )
 
 selects.config_setting_group(
-    name = "android_or_qnx_with_shm",
+    name = "qnx_with_shm",
     match_all = [
-        ":android_or_qnx",
+        "@platforms//os:qnx",
         ":enable_shm_on",
     ],
 )
@@ -64,9 +64,17 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
-    name = "android_or_qnx_without_shm",
+    name = "android_without_shm",
     match_all = [
-        ":android_or_qnx",
+        "@platforms//os:android",
+        ":enable_shm_off",
+    ],
+)
+
+selects.config_setting_group(
+    name = "qnx_without_shm",
+    match_all = [
+        "@platforms//os:qnx",
         ":enable_shm_off",
     ],
 )
@@ -104,10 +112,17 @@ cache_entries_linux_and_macos = {
     "ENABLE_SOURCE_SPECIFIC_MULTICAST": "ON",
 }
 
-cache_entries_qnx = {
+cache_entries_android_and_qnx = {
     "ENABLE_SOURCE_SPECIFIC_MULTICAST": "OFF",
     "ENABLE_IPV6": "OFF",
-    "CMAKE_SYSTEM_NAME": "ANDROID_OR_QNX",
+}
+
+cache_entries_android = {
+    "CMAKE_SYSTEM_NAME": "Android",
+}
+
+cache_entries_qnx = {
+    "CMAKE_SYSTEM_NAME": "QNX",
 }
 
 cache_entries_with_shm = {
@@ -132,9 +147,16 @@ cmake(
                 cache_entries_linux_and_macos,
                 cache_entries_with_shm,
             ),
-            ":android_or_qnx_with_shm": dicts.add(
+            ":android_with_shm": dicts.add(
+                cache_entries,
+                cache_entries_android,
+                cache_entries_android_and_qnx,
+                cache_entries_with_shm,
+            ),
+            ":qnx_with_shm": dicts.add(
                 cache_entries,
                 cache_entries_qnx,
+                cache_entries_android_and_qnx,
                 cache_entries_with_shm,
             ),
             ":linux_or_macos_without_shm": dicts.add(
@@ -142,9 +164,16 @@ cmake(
                 cache_entries_linux_and_macos,
                 cache_entries_without_shm,
             ),
-            ":android_or_qnx_without_shm": dicts.add(
+            ":android_without_shm": dicts.add(
+                cache_entries,
+                cache_entries_android,
+                cache_entries_android_and_qnx,
+                cache_entries_without_shm,
+            ),
+            ":qnx_without_shm": dicts.add(
                 cache_entries,
                 cache_entries_qnx,
+                cache_entries_android_and_qnx,
                 cache_entries_without_shm,
             ),
         },
@@ -152,10 +181,10 @@ cmake(
     ),
     generate_args = ["-GNinja"],
     lib_source = ":all_srcs",
-    linkopts = select(
+    linkopts = selects.with_or(
         {
             ":linux_or_macos": ["-lpthread"],
-            ":android_or_qnx": [],
+            ("@platforms//os:android", "@platforms//os:qnx"): [],
         },
         no_match_error = "Supported OSs: Android, Linux, macOS, QNX",
     ),

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -13,8 +13,12 @@ cache_entries = {
     "CCACHE": "OFF",
 }
 
+cache_entries_android = {
+    "CMAKE_SYSTEM_NAME": "Android",
+}
+
 cache_entries_qnx = {
-    "CMAKE_SYSTEM_NAME": "ANDROID_OR_QNX",
+    "CMAKE_SYSTEM_NAME": "QNX",
 }
 
 # Depends on libacl. On Ubuntu install as `sudo apt-get install libacl1-dev`.
@@ -27,7 +31,11 @@ cmake(
     cache_entries = selects.with_or(
         {
             ("@platforms//os:linux", "@platforms//os:macos"): cache_entries,
-            ("@platforms//os:android", "@platforms//os:qnx"): dicts.add(
+            "@platforms//os:android": dicts.add(
+                cache_entries,
+                cache_entries_android,
+            ),
+            "@platforms//os:qnx": dicts.add(
                 cache_entries,
                 cache_entries_qnx,
             ),


### PR DESCRIPTION
#165 added support for Android, and correctly combined a lot of settings with the QNX platform. However, it also started passing `CMAKE_SYSTEM_NAME=ANDROID_OR_QNX` to CMake, which is not a supported value. Instead pass `Android` or `QNX` depending on the current platform (see docs [here](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html)).

I had to re-organize a few config settings and some groups of flags passed together, but functionally the `CMAKE_SYSTEM_NAME` is the only value that's now passed different for the `Android` and `QNX` platform.