### PR TITLE
Upgrade 3rd party deps to prepare Bzlmod compat

### DIFF
--- a/repositories/asio.BUILD.bazel
+++ b/repositories/asio.BUILD.bazel
@@ -1,3 +1,5 @@
+# Same as https://github.com/bazelbuild/bazel-central-registry/blob/dcff901/modules/asio/1.31.0/overlay/BUILD.bazel
+
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(

--- a/repositories/foxglove_bridge.BUILD.bazel
+++ b/repositories/foxglove_bridge.BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
     copts = ["-std=c++17"],
     includes = ["foxglove_bridge_base/include"],
     deps = [
+        "@boringssl//:ssl",
         "@nlohmann_json//:json",
         "@websocketpp",
     ],

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -32,9 +32,9 @@ def ros2_workspace_repositories():
         http_archive,
         name = "fmt",
         build_file = "@com_github_mvukov_rules_ros2//repositories:fmt.BUILD.bazel",
-        sha256 = "5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2",
-        strip_prefix = "fmt-9.1.0",
-        url = "https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz",
+        sha256 = "1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811",
+        strip_prefix = "fmt-10.2.1",
+        url = "https://github.com/fmtlib/fmt/archive/10.2.1.tar.gz",
     )
 
     maybe(
@@ -155,12 +155,9 @@ def ros2_workspace_repositories():
         http_archive,
         name = "zlib",
         build_file = "@com_github_mvukov_rules_ros2//repositories:zlib.BUILD.bazel",
-        sha256 = "d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98",
-        strip_prefix = "zlib-1.2.13",
-        urls = [
-            "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.xz",
-            "https://zlib.net/zlib-1.2.13.tar.xz",
-        ],
+        sha256 = "8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
+        strip_prefix = "zlib-1.3",
+        urls = ["https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.xz"],
     )
 
     maybe(
@@ -197,18 +194,18 @@ def ros2_workspace_repositories():
         http_archive,
         name = "lz4",
         build_file = "@com_github_mvukov_rules_ros2//repositories:lz4.BUILD.bazel",
-        sha256 = "4ec935d99aa4950eadfefbd49c9fad863185ac24c32001162c44a683ef61b580",
-        strip_prefix = "lz4-1.9.3",
-        urls = ["https://github.com/lz4/lz4/archive/refs/tags/v1.9.3.zip"],
+        sha256 = "0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b",
+        strip_prefix = "lz4-1.9.4",
+        urls = ["https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz"],
     )
 
     maybe(
         http_archive,
         name = "yaml-cpp",
         build_file = "@com_github_mvukov_rules_ros2//repositories:yaml-cpp.BUILD.bazel",
-        sha256 = "43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3",
-        strip_prefix = "yaml-cpp-yaml-cpp-0.7.0",
-        urls = ["https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"],
+        sha256 = "fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16",
+        strip_prefix = "yaml-cpp-0.8.0",
+        urls = ["https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
Upgrade 3rd party deps to prepare Bzlmod compatibility.
Split off https://github.com/mvukov/rules_ros2/pull/238