### PR TITLE
Add Python transition attrs to _ROS2_COLLECTOR_ATTR_ASPECTS

### DIFF
--- a/ros2/plugin_aspects.bzl
+++ b/ros2/plugin_aspects.bzl
@@ -38,15 +38,16 @@ Ros2PluginCollectorAspectInfo = provider(
     ],
 )
 
-_ROS2_COLLECTOR_ATTR_ASPECTS = ["data", "deps"]
+# From https://github.com/bazelbuild/rules_python/blob/0.33.2/python/config_settings/transition.bzl#L121-L140
+_py_transition_attrs = ["target", "tools"]
+
+_ROS2_COLLECTOR_ATTR_ASPECTS = ["data", "deps"] + _py_transition_attrs
 
 def _get_list_attr(rule_attr, attr_name):
-    if not hasattr(rule_attr, attr_name):
-        return []
-    candidate = getattr(rule_attr, attr_name)
-    if type(candidate) != "list":
-        fail("Expected a list for attribute `{}`!".format(attr_name))
-    return candidate
+    candidate = getattr(rule_attr, attr_name, [])
+    if type(candidate) == type([]):
+        return candidate
+    return [candidate]
 
 def _collect_deps(rule_attr, attr_name, provider_info):
     return [


### PR DESCRIPTION
Split off https://github.com/mvukov/rules_ros2/pull/238

It looks like things have changed in https://github.com/bazelbuild/rules_python/commit/611eda87e48a3943808216cf4e4de875040b09aa but it might be nice to keep this change to stay compatible for users who need to patch-in older rules_python.