### PR TITLE
fix: add rclpy dependency to rosbag2_py

### DIFF
--- a/repositories/rosbag2.BUILD.bazel
+++ b/repositories/rosbag2.BUILD.bazel
@@ -341,7 +341,10 @@ py_library(
     ],
     imports = ["rosbag2_py"],
     visibility = ["//visibility:public"],
-    deps = ["@ros2_rpyutils//:rpyutils"],
+    deps = [
+        "@ros2_rclpy//:rclpy",
+        "@ros2_rpyutils//:rpyutils",
+    ],
 )
 
 py_library(


### PR DESCRIPTION
Though not used from Python code, in the C++ bindings `rclpy.duration` is [imported](https://github.com/ros2/rosbag2/blob/humble/rosbag2_py/src/rosbag2_py/_storage.cpp#L35). This showed when migrating to the bzlmod branch. Not sure why it didn't show up before. Probably because there was some `rclpy` dep elsewhere.