### PR TITLE
Add missing imports for py_libraries

### DIFF
--- a/repositories/diagnostics.BUILD.bazel
+++ b/repositories/diagnostics.BUILD.bazel
@@ -21,6 +21,7 @@ ros2_cpp_library(
 py_library(
     name = "py_diagnostic_updater",
     srcs = glob(["diagnostic_updater/diagnostic_updater/*.py"]),
+    imports = ["diagnostic_updater"],
     visibility = ["//visibility:public"],
     deps = [
         "@ros2_common_interfaces//:py_diagnostic_msgs",

--- a/repositories/rpyutils.BUILD.bazel
+++ b/repositories/rpyutils.BUILD.bazel
@@ -6,5 +6,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "rpyutils",
     srcs = glob(["rpyutils/*.py"]),
+    imports = ["."],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
When depending on rules_ros2 libraries from [rules_py](https://github.com/aspect-build/rules_py)'s rules, `rpyutils` is not on the path. For `diagnostic_updater`, the required import path even with `rules_python` is `diagnostic_updater.diagnostic_updater`, when it should only be `diagnostic_updater`. Adding the import to each `py_library` fixes this.