### PR TITLE
Patch rclcpp to not allocate in signal handlers

### DIFF
--- a/repositories/patches/rclcpp_do-not-allocate-in-signal-handler.patch
+++ b/repositories/patches/rclcpp_do-not-allocate-in-signal-handler.patch
@@ -1,0 +1,21 @@
+diff --git a/rclcpp/src/rclcpp/signal_handler.cpp b/rclcpp/src/rclcpp/signal_handler.cpp
+index 35ceb56..47be41d 100644
+--- a/rclcpp/src/rclcpp/signal_handler.cpp
++++ b/rclcpp/src/rclcpp/signal_handler.cpp
+@@ -68,7 +68,6 @@ void
+ SignalHandler::signal_handler(
+   int signum, siginfo_t * siginfo, void * context)
+ {
+-  RCLCPP_INFO(SignalHandler::get_logger(), "signal_handler(signum=%d)", signum);
+   auto & instance = SignalHandler::get_global_signal_handler();
+ 
+   auto old_signal_handler = instance.get_old_signal_handler(signum);
+@@ -258,7 +257,7 @@ SignalHandler::deferred_signal_handler()
+ {
+   while (true) {
+     if (signal_received_.exchange(false)) {
+-      RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): shutting down");
++      RCLCPP_INFO(get_logger(), "deferred_signal_handler(): shutting down");
+       for (auto context_ptr : rclcpp::get_contexts()) {
+         if (context_ptr->get_init_options().shutdown_on_signal) {
+           RCLCPP_DEBUG(

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -173,7 +173,11 @@ def ros2_repositories_impl():
         build_file = "@com_github_mvukov_rules_ros2//repositories:rclcpp.BUILD.bazel",
         patch_cmds = ["patch"],
         patch_args = ["-p1"],
-        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_fix-maybe-uninitialized-warning.patch", "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_ts_libs_ownership.patch"],
+        patches = [
+            "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_do-not-allocate-in-signal-handler.patch",
+            "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_fix-maybe-uninitialized-warning.patch",
+            "@com_github_mvukov_rules_ros2//repositories/patches:rclcpp_ts_libs_ownership.patch",
+        ],
         sha256 = "f2102798b3fd7c11eba2728b35f5aca34add9acc7beb42d0a7e9cfcda12eea3d",
         strip_prefix = "rclcpp-16.0.11",
         url = "https://github.com/ros2/rclcpp/archive/refs/tags/16.0.11.tar.gz",


### PR DESCRIPTION
The RCLCPP_INFO causes allocations (due to libfmt iirc) that may (and has) lead to deadlocks.
See https://developer.arm.com/documentation/101136/22-1-3/General-troubleshooting/Memory-debugging/Deadlock-when-calling-printf-or-malloc-from-a-signal-handler