### PR TITLE
Ignore static alloc leak in class_loader

### DIFF
--- a/repositories/patches/ros2_class_loader-lsan.-213.patch
+++ b/repositories/patches/ros2_class_loader-lsan.-213.patch
@@ -1,0 +1,42 @@
+From 1b432c9355e44bb437c0e52464521bc1646471c0 Mon Sep 17 00:00:00 2001
+From: "xinyu.wang" <comicfans44@gmail.com>
+Date: Wed, 4 Sep 2024 22:05:08 +0200
+Subject: [PATCH] suppress sanitizer warning about (expected) leak
+
+Signed-off-by: xinyu.wang <comicfans44@gmail.com>
+---
+ include/class_loader/class_loader_core.hpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git include/class_loader/class_loader_core.hpp include/class_loader/class_loader_core.hpp
+index 6741864..c5913ae 100644
+--- include/class_loader/class_loader_core.hpp
++++ include/class_loader/class_loader_core.hpp
+@@ -163,6 +163,15 @@ bool hasANonPurePluginLibraryBeenOpened();
+ CLASS_LOADER_PUBLIC
+ void hasANonPurePluginLibraryBeenOpened(bool hasIt);
+ 
++#if defined(__has_feature)
++#if __has_feature(address_sanitizer) // for clang
++#define __SANITIZE_ADDRESS__         // GCC already sets this
++#endif
++#endif
++
++#if defined(__SANITIZE_ADDRESS__)
++#include <sanitizer/lsan_interface.h>
++#endif
+ // Plugin Functions
+ 
+ /**
+@@ -207,6 +216,11 @@ void registerPlugin(const std::string & class_name, const std::string & base_cla
+   // Create factory
+   impl::AbstractMetaObject<Base> * new_factory =
+     new impl::MetaObject<Derived, Base>(class_name, base_class_name);
++
++#if defined(__SANITIZE_ADDRESS__)
++  __lsan_ignore_object(new_factory);
++#endif
++
+   new_factory->addOwningClassLoader(getCurrentlyActiveClassLoader());
+   new_factory->setAssociatedLibraryPath(getCurrentlyLoadingLibraryName());
+ 

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -16,6 +16,7 @@ def ros2_repositories_impl():
         http_archive,
         name = "ros2_class_loader",
         build_file = "@com_github_mvukov_rules_ros2//repositories:class_loader.BUILD.bazel",
+        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:ros2_class_loader-lsan.-213.patch"],
         sha256 = "a85a99b93fcad7c8d9686672b8e3793200b1da9d8feab7ab3a9962e34ab1f675",
         strip_prefix = "class_loader-2.2.0",
         url = "https://github.com/ros/class_loader/archive/refs/tags/2.2.0.tar.gz",


### PR DESCRIPTION
Improve LSan compatibility via https://github.com/ros/class_loader/pull/213 patch to ignore static alloc leak in class_loader