### PR TITLE
Add rosbag2 keyboard handler patch

### DIFF
--- a/repositories/patches/rosbag2_keyboard-handler.patch
+++ b/repositories/patches/rosbag2_keyboard-handler.patch
@@ -1,0 +1,38 @@
+diff --git a/rosbag2_transport/src/rosbag2_transport/recorder.cpp b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+index 4d0c2649..aa303b8d 100644
+--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
++++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+@@ -95,11 +95,16 @@ Recorder::Recorder(
+   }
+
+   std::string key_str = enum_key_code_to_str(Recorder::kPauseResumeToggleKey);
+-  toggle_paused_key_callback_handle_ =
+-    keyboard_handler_->add_key_press_callback(
+-    [this](KeyboardHandler::KeyCode /*key_code*/,
+-    KeyboardHandler::KeyModifiers /*key_modifiers*/) {this->toggle_paused();},
+-    Recorder::kPauseResumeToggleKey);
++  if (keyboard_handler_) {
++    toggle_paused_key_callback_handle_ =
++        keyboard_handler_->add_key_press_callback(
++            [this](KeyboardHandler::KeyCode /*key_code*/,
++                   KeyboardHandler::KeyModifiers /*key_modifiers*/) {
++              this->toggle_paused();
++            },
++            Recorder::kPauseResumeToggleKey);
++  }
++
+   // show instructions
+   RCLCPP_INFO_STREAM(
+     get_logger(),
+@@ -112,7 +117,10 @@ Recorder::Recorder(
+
+ Recorder::~Recorder()
+ {
+-  keyboard_handler_->delete_key_press_callback(toggle_paused_key_callback_handle_);
++  if (keyboard_handler_) {
++    keyboard_handler_->delete_key_press_callback(
++        toggle_paused_key_callback_handle_);
++  }
+   stop();
+ }
+

--- a/repositories/ros2_repositories_impl.bzl
+++ b/repositories/ros2_repositories_impl.bzl
@@ -293,7 +293,10 @@ def ros2_repositories_impl():
         name = "ros2_rosbag2",
         build_file = "@com_github_mvukov_rules_ros2//repositories:rosbag2.BUILD.bazel",
         patch_args = ["-p1"],
-        patches = ["@com_github_mvukov_rules_ros2//repositories/patches:rosbag2_relax_plugin_errors.patch"],
+        patches = [
+            "@com_github_mvukov_rules_ros2//repositories/patches:rosbag2_relax_plugin_errors.patch",
+            "@com_github_mvukov_rules_ros2//repositories/patches:rosbag2_keyboard-handler.patch",
+        ],
         sha256 = "035f4346bdc4bee7b86fed277658bc045b627f5517085fdf3a453285b274ee3c",
         strip_prefix = "rosbag2-0.15.13",
         url = "https://github.com/ros2/rosbag2/archive/refs/tags/0.15.13.tar.gz",


### PR DESCRIPTION
This removes the registering a keyboard handler from the system when using the rosbag2 keyboard handler.

With this patch, you can set nullptr as keyboard handler and it will not fiddle with the system internals. If not supplied, it will work as before...

Background is that this causes side effects on the system:

- Terminal will ignore any further inputs and freeze.
- Tests will not properly finish and crash on gtest cleanup code.