### PR TITLE
Fix RMW_LIBRARY_PATH define in presence of transitions

### DIFF
--- a/repositories/rmw_implementation.BUILD.bazel
+++ b/repositories/rmw_implementation.BUILD.bazel
@@ -15,9 +15,7 @@ ros2_cpp_library(
         "@ros2_rmw_cyclonedds//:rmw_cyclonedds",
     ],
     includes = ["include"],
-    local_defines = [
-        "RMW_LIBRARY_PATH=\\\"$(rootpath @ros2_rmw_cyclonedds//:rmw_cyclonedds)\\\"",
-    ],
+    local_defines = ['RMW_LIBRARY_PATH=\\"../ros2_rmw_cyclonedds/librmw_cyclonedds.so\\"'],
     visibility = ["//visibility:public"],
     deps = [
         "@ros2_rcpputils//:rcpputils",


### PR DESCRIPTION
This fixes the below error
```
unknown file: Failure
C++ exception with description "Failed to deserialize ROS message.: failed to load shared library 'external/ros2_rmw_cyclonedds/librmw_cyclonedds.so' due to dlopen error: external/ros2_rmw_cyclonedds/librmw_cyclonedds.so: cannot open shared object file: No such file or directory, at external/ros2_rcutils/src/shared_library.c:96, at external/ros2_rmw_implementation/rmw_implementation/src/functions.cpp:90" thrown in the test body.
```

Which you will get when transitions (e.g. via with_cfg.bzl) are at play, because the `k8-fastbuild` and friends will not be correct anymore, it has to be `k8-fastbuild-ST-61f4e3852c4b` or similar, depending on configuration.

Using `../` instead is always correct because of the runfiles structure at runtime.