### PR TITLE
Add WORKSPACE.bzlmod

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,3 @@
+# This file is intentionally kept empty.
+# It is used for the migration to Bzlmod.
+# It can be removed once we upgraded to Bazel 8+.


### PR DESCRIPTION
This is used when running with "--enable_bzlmod" and "--enable_workspace" (default in Bazel 7).