### PR TITLE
Add support for Python 3.13

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,7 @@ _PYTHON_VERSIONS = [
     "3.10",
     "3.11",
     "3.12",
+    "3.13",
 ]
 
 _DEFAULT_PYTHON = "3.10"

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -271,9 +271,9 @@ def ros2_repositories():
         http_archive,
         name = "ros2_xacro",
         build_file = "@com_github_mvukov_rules_ros2//repositories:xacro.BUILD.bazel",
-        sha256 = "a8802a5b48f7479bae1238e822ac4ebb47660221eb9bc40a608e899d60f3f7e4",
-        strip_prefix = "xacro-2.0.9",
-        urls = ["https://github.com/ros/xacro/archive/refs/tags/2.0.9.tar.gz"],
+        sha256 = "6df0d44af8a6bf9f23f0536ce167a0cd7b4c01281100dfea7e17d504363b424d",
+        strip_prefix = "xacro-2.0.13",
+        urls = ["https://github.com/ros/xacro/archive/refs/tags/2.0.13.tar.gz"],
     )
 
     # Version copied from https://github.com/ros2/orocos_kdl_vendor/blob/0.2.5/orocos_kdl_vendor/CMakeLists.txt#L58.


### PR DESCRIPTION
This requires an update of the `xacro` dependency.