### PR TITLE
Disable CycloneDDS LTO

### DIFF
--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -98,6 +98,7 @@ cache_entries = {
     "BUILD_TESTING": "OFF",
     "ENABLE_DEADLINE_MISSED": "ON",
     "ENABLE_LIFESPAN": "ON",
+    "ENABLE_LTO": "OFF",
     "ENABLE_NETWORK_PARTITIONS": "ON",
     "ENABLE_SECURITY": "OFF",
     "ENABLE_SSL": "OFF",  # TODO(mvukov) Here we could use openssl/boringssl.


### PR DESCRIPTION
The CMake build of CycloneDDS is causing nondeterminism in our build (i.e. rebuilding build artifacts causes hash changes).

Disabling LTO on the CycloneDDS CMake build helps with this.