### PR TITLE
Explicitly load rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,9 @@ build --sandbox_default_allow_network=false
 # Flipped to true in Bazel 8. This is a recommended flag.
 build --incompatible_disallow_empty_glob
 
+# Will probably be flipped in Bazel 9.
+build --incompatible_autoload_externally=
+
 # Don't let local Python site packages leak into the build and cause problems
 common --action_env=PYTHONNOUSERSITE=1
 # Don't let environment variables like $PATH sneak into the build,

--- a/repositories/clang_configure.bzl
+++ b/repositories/clang_configure.bzl
@@ -1,7 +1,7 @@
 def _clang_configure_impl(repository_ctx):
     clang_bin_path = repository_ctx.which("clang")
     if clang_bin_path == None:
-        fail("Failed to find clang executable:\n{}".format(result.stderr))
+        fail("Failed to find clang executable")
 
     repository_ctx.symlink(clang_bin_path, "clang")
 

--- a/ros2/ament.bzl
+++ b/ros2/ament.bzl
@@ -24,6 +24,7 @@ load(
     "expand_template_impl",
 )
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "PyInfo")
 
 _AMENT_SETUP_MODULE = "ament_setup"
 

--- a/ros2/cc_defs.bzl
+++ b/ros2/cc_defs.bzl
@@ -4,6 +4,8 @@
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "sh_launcher", "split_kwargs")
 load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "C_COPTS")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 def _ros2_cc_target(target, lang, name, ros2_package_name, **kwargs):
     if lang == "c":
@@ -93,7 +95,7 @@ def _ros2_cpp_exec(target, name, ros2_package_name, set_up_ament, idl_deps, **kw
         testonly = is_test,
     )
 
-    sh_target = native.sh_test if is_test else native.sh_binary
+    sh_target = sh_test if is_test else sh_binary
     sh_target(
         name = name,
         srcs = [launcher],

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -17,7 +17,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "C_COPTS")
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "PyInfo", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
 
 Ros2InterfaceInfo = provider(

--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -4,6 +4,8 @@
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "sh_launcher", "split_kwargs")
 load("@com_github_mvukov_rules_ros2//third_party:symlink.bzl", "symlink")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 def _ros2_py_exec(target, name, srcs, main, set_up_ament, **kwargs):
     is_test = target == py_test
@@ -38,7 +40,7 @@ def _ros2_py_exec(target, name, srcs, main, set_up_ament, **kwargs):
         testonly = is_test,
     )
 
-    sh_target = native.sh_test if is_test else native.sh_binary
+    sh_target = sh_test if is_test else sh_binary
     sh_target(
         name = name,
         srcs = [launcher],

--- a/ros2/rust_defs.bzl
+++ b/ros2/rust_defs.bzl
@@ -3,6 +3,7 @@
 
 load("@com_github_mvukov_rules_ros2//ros2:ament.bzl", "sh_launcher", "split_kwargs")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 def ros2_rust_test(name, **kwargs):
     """ Defines a ROS 2 Rust test.
@@ -38,7 +39,7 @@ def ros2_rust_test(name, **kwargs):
         testonly = True,
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [launcher],
         data = [target_impl],

--- a/ros2/test/pluginlib/BUILD.bazel
+++ b/ros2/test/pluginlib/BUILD.bazel
@@ -3,6 +3,7 @@ load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_binary", "ros2
 load("@com_github_mvukov_rules_ros2//ros2:plugin.bzl", "ros2_plugin")
 load("@com_github_mvukov_rules_ros2//ros2:py_defs.bzl", "ros2_py_binary", "ros2_py_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 cc_library(
     name = "polygon_base",


### PR DESCRIPTION
The native ones are deprecated and will be removed in a future Bazel version.