### PR TITLE
[WIP] Support testonly in `ros2_py_test()`

### DIFF
--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -15,7 +15,7 @@ def _ros2_py_exec(target, name, srcs, main, set_up_ament, testonly, **kwargs):
 
     launcher_target_kwargs, binary_kwargs = split_kwargs(**kwargs)
     target_impl = name + "_impl"
-    target(name = target_impl, srcs = srcs, main = main, tags = ["manual"], **binary_kwargs)
+    target(name = target_impl, srcs = srcs, main = main, tags = ["manual"], testonly = testonly, **binary_kwargs)
 
     target_impl_symlink = target_impl + "_symlink"
     symlink(

--- a/ros2/py_defs.bzl
+++ b/ros2/py_defs.bzl
@@ -15,7 +15,14 @@ def _ros2_py_exec(target, name, srcs, main, set_up_ament, testonly, **kwargs):
 
     launcher_target_kwargs, binary_kwargs = split_kwargs(**kwargs)
     target_impl = name + "_impl"
-    target(name = target_impl, srcs = srcs, main = main, tags = ["manual"], testonly = testonly, **binary_kwargs)
+    target(
+        name = target_impl,
+        srcs = srcs,
+        main = main,
+        tags = ["manual"],
+        testonly = testonly,
+        **binary_kwargs,
+    )
 
     target_impl_symlink = target_impl + "_symlink"
     symlink(

--- a/ros2/test/launch_pytest/BUILD.bazel
+++ b/ros2/test/launch_pytest/BUILD.bazel
@@ -34,6 +34,14 @@ ros2_test(
     deps = ["@ros2_rclpy//:rclpy"],
 )
 
+
+# A testonly target to make sure that ros2_py_test can depend on testonly targets.
+filegroup(
+    name = "some_test_files",
+    srcs = [],
+    testonly = True,
+)
+
 ros2_py_test(
     name = "ros2_py_test_rclpy_init_test",
     size = "small",
@@ -43,4 +51,7 @@ ros2_py_test(
         "@ros2_launch//:launch_pytest",
         "@ros2_rclpy//:rclpy",
     ],
+    data = [
+        ":some_test_files",
+    ]
 )


### PR DESCRIPTION
Currently `ros2_py_test()` targets appear not to be able to depend on `testonly` targets. Propagate `testonly` into the inner `py_test` target correctly.

TODO(mikebauer) Figure out the right way to test this. The current way of testing this is to add an empty testonly `filegroup()` dependency to `//ros2/test/launch_pytest:ros2_py_test_rclpy_init_test` which fails without the `py_defs.bzl` changes.