### PR TITLE
Reworked Rust repository to work with MODULE setup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,20 +31,6 @@ bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "ros2_rust",
-    build_file = "//repositories:ros2_rust.BUILD.bazel",
-    patch_args = ["-p1"],
-    patches = [
-        "//repositories/patches:ros2_rust_fix_rclrs.patch",
-        "//repositories/patches:ros2_rust_fix_rosidl_generator.patch",
-        "//repositories/patches:ros2_rust_fix_rosidl_runtime.patch",
-    ],
-    sha256 = "6ef8722c2dde10e5c2fc1b9aef6ec3cc397f8cda40d58743045584aa59a6b0c8",
-    strip_prefix = "ros2_rust-9a845c17873cbdf49e8017d5f0af6d8f795589cc",
-    urls = ["https://github.com/ros2-rust/ros2_rust/archive/9a845c17873cbdf49e8017d5f0af6d8f795589cc.zip"],
-)
-
 _PYTHON_VERSIONS = [
     "3.10",
     "3.11",
@@ -167,6 +153,7 @@ use_repo(
     "ros2_rosidl_runtime_py",
     "ros2_rosidl_typesupport",
     "ros2_rpyutils",
+    "ros2_rust",
     "ros2_tracing",
     "ros2_unique_identifier_msgs",
     "ros2_urdfdom",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -35,6 +35,7 @@ use_repo(
     "ros2_launch_ros",
     "ros2_rcl_interfaces",
     "ros2_rclcpp",
+    "ros2_rust",
     # Required for bazel run:
     "ros2_rclpy",
     "ros2_rosidl",

--- a/repositories/rust_setup_stage_1.bzl
+++ b/repositories/rust_setup_stage_1.bzl
@@ -16,7 +16,9 @@ def rust_setup_stage_1():
         strip_prefix = "extensions/bindgen",
         url = "https://github.com/bazelbuild/rules_rust/releases/download/0.63.0/rules_rust-0.63.0.tar.gz",
     )
+    ros2_rust_repositories()
 
+def ros2_rust_repositories():
     maybe(
         http_archive,
         name = "ros2_rust",

--- a/ros2/extensions.bzl
+++ b/ros2/extensions.bzl
@@ -1,9 +1,11 @@
 load("//repositories:clang_configure.bzl", "clang_configure")
 load("//repositories:repositories.bzl", "ros2_repositories")
+load("//repositories:rust_setup_stage_1.bzl", "ros2_rust_repositories")
 
 def _non_module_deps_impl(mctx):
     ros2_repositories()
     clang_configure(name = "rules_ros2_config_clang")
+    ros2_rust_repositories()
 
 non_module_deps = module_extension(
     implementation = _non_module_deps_impl,


### PR DESCRIPTION
After doing some digging, it looks like the `ros2_rust`  being in the top level module in an `http_archive` didn't surface it out to anyone depending on it. You can see an example of how the failure maifests itself in rdelfin/ros_test#1. To resolve this, I've moved the `ros2_rust` fules down into `repositories.bzl` so it can be imported and optionally enabled by users.

One thing that's still not clear to me however, is why CI is passing. I ran a fork of this repo on github actions but disabled both the caching and remote execution and that seems to have gotten CI to fail, so it seems to me like there might be some bad caching going on, but I'm not familiar enough with this to really say with any certainty.

This fixes #523.