### PR TITLE
clang_configure: add /usr/lib/libclang.so to search paths

### DIFF
--- a/repositories/clang_configure.bzl
+++ b/repositories/clang_configure.bzl
@@ -5,14 +5,17 @@ def _clang_configure_impl(repository_ctx):
 
     repository_ctx.symlink(clang_bin_path, "clang")
 
-    result = repository_ctx.execute([clang_bin_path, "--version"])
+    # find libclang.so
+    result = repository_ctx.execute(["realpath", "-e", "/usr/lib/libclang.so"])
     if result.return_code != 0:
-        fail("Failed to get clang version")
-    clang_version = result.stdout.split(" ")[3].split(".")[0]
+        result = repository_ctx.execute([clang_bin_path, "--version"])
+        if result.return_code != 0:
+            fail("Failed to get clang version")
+        clang_version = result.stdout.split(" ")[3].split(".")[0]
 
-    result = repository_ctx.execute(["realpath", "/usr/lib/llvm-{}/lib/libclang.so.1".format(clang_version)])
-    if result.return_code != 0:
-        fail("Failed to fetch libclang_path:\n{}".format(result.stderr))
+        result = repository_ctx.execute(["realpath", "/usr/lib/llvm-{}/lib/libclang.so.1".format(clang_version)])
+        if result.return_code != 0:
+            fail("Failed to fetch libclang_path:\n{}".format(result.stderr))
     libclang_path = result.stdout.strip()
     repository_ctx.symlink(libclang_path, "libclang.so")
 


### PR DESCRIPTION
On ArchlinuxARM, running `clang --version` returns:
```
clang version 20.1.8
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
compared to Ubuntu:
```
Ubuntu clang version 14.0.0-1ubuntu1.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
which breaks the build with:
```
@@com_github_mvukov_rules_ros2+//repositories/rust:bindgen_toolchain_impl depends on @@com_github_mvukov_rules_ros2++non_module_deps+rules_ros2_config_clang//:libclang in repository @@com_github_mvukov_rules_ros2++non_module_deps+rules_ros2_config_clang which failed to fetch. no such package '@@com_github_mvukov_rules_ros2++non_module_deps+rules_ros2_config_clang//': Failed to fetch libclang_path:
realpath: '/usr/lib/llvm-aarch64-unknown-linux-gnu'$'\n''Thread/lib/libclang.so.1': No such file or directory
```
On ArchlinuxARM, `libclang.so` is installed directly under `/usr/lib`, so theres no need to get the version first. This PR adds a search for `libclang.so` in `/usr/lib` first, and falls back to the existing lookup if it’s not found.

I also evaluated a more hermetic approach using [toolchains_llvm](https://github.com/bazel-contrib/toolchains_llvm).
Theres `@llvm_toolchain_llvm//:bin/clang` and `@llvm_toolchain_llvm//:lib/libclang.so` target, but it can be added to the root bazel module only. Another issue is size - extracted toolchain is about 6 GB and takes more than 400 seconds to extract on Raspberry Pi - not sure if its worth it. Maybe there could be some `rules_ros2` option to provide `rules_ros2_config_clang` replacement if root module is already using `toolchains_llvm`...


