### PR TITLE
Fix foxglove_bridge example build by adding missing dependencies

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -31,11 +31,16 @@ use_repo(
     # Check the rules_ros2 root MODULE.bazel for a full list of available non-module repos
     # Required for bazel test:
     "ros2_common_interfaces",
+    "ros2_geometry2",
     "ros2_launch",
     "ros2_launch_ros",
+    "ros2_message_filters",
     "ros2_rcl_interfaces",
     "ros2_rclcpp",
+    "ros2_rcutils",
+    "ros2_robot_state_publisher",
     "ros2_rust",
+    "ros2_unique_identifier_msgs",
     "ros2cli",
     # Required for bazel run:
     "ros2_rclpy",

--- a/repositories/geometry2.BUILD.bazel
+++ b/repositories/geometry2.BUILD.bazel
@@ -47,9 +47,11 @@ ros2_cpp_library(
     name = "tf2",
     srcs = glob([
         "tf2/src/*.cpp",
-        "tf2/src/*.hpp",
     ]),
-    hdrs = glob(["tf2/include/**/*.h"]),
+    hdrs = glob([
+        "tf2/include/**/*.h",
+        "tf2/include/**/*.hpp",
+    ]),
     includes = ["tf2/include"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
## Problem

The `foxglove_bridge` example exhibited inconsistent build behavior:
- `bazel run //foxglove_bridge:publisher` worked successfully
- `bazel build //foxglove_bridge` failed with "repository not found" errors

## Root Cause

The issue was due to **different dependency requirements between targets** in the same package:

1. The `publisher` target only depends on repositories already declared in `examples/MODULE.bazel` (`ros2_common_interfaces`, `ros2_rclcpp`)
2. The `foxglove_bridge` launch target requires additional repositories that were not exposed via `use_repo()`:
   - `@ros2_geometry2` (for tf2_msgs interface types)
   - `@ros2_robot_state_publisher` (for robot state publisher node)
   - Transitive dependencies: `ros2_unique_identifier_msgs`, `ros2_message_filters`, `ros2_rcutils`

In Bzlmod, repositories must be explicitly declared visible using `use_repo()`, even if they're defined in the extension.

## Changes Made

### 1. `examples/MODULE.bazel`

Added missing repositories to the `use_repo()` call:
- `ros2_geometry2`
- `ros2_message_filters`
- `ros2_rcutils`
- `ros2_robot_state_publisher`
- `ros2_unique_identifier_msgs`

### 2. `repositories/geometry2.BUILD.bazel`

Fixed two BUILD file issues discovered during compilation:
- **Removed invalid glob pattern**: `tf2/src/*.hpp` - no `.hpp` files exist in `src/` directory
- **Added missing header pattern**: `tf2/include/**/*.hpp` - the geometry2 library uses both `.h` and `.hpp` header files, but only `.h` files were being included, causing compilation errors (`tf2/buffer_core.hpp: No such file or directory`)

## Testing

After these changes:
- `bazel run //foxglove_bridge:publisher` - still works
- `bazel build //foxglove_bridge` - now works successfully