### PR TITLE
Update deps and add load statements for Bazel 9 support

### DIFF
--- a/repositories/clang_configure.bzl
+++ b/repositories/clang_configure.bzl
@@ -17,6 +17,8 @@ def _clang_configure_impl(repository_ctx):
     repository_ctx.symlink(libclang_path, "libclang.so")
 
     repository_ctx.file("BUILD.bazel", """\
+load("@rules_cc//cc:defs.bzl", "cc_import")
+
 exports_files([
     "clang",
 ])

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "C_COPTS")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_python//python:defs.bzl", "PyInfo", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")

--- a/ros2/plugin.bzl
+++ b/ros2/plugin.bzl
@@ -28,6 +28,7 @@ load(
     "Ros2PluginInfo",
     "create_dynamic_library",
 )
+load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _ros2_plugin_impl(ctx):

--- a/ros2/plugin_aspects.bzl
+++ b/ros2/plugin_aspects.bzl
@@ -20,6 +20,7 @@ load(
     "IdlAdapterAspectInfo",
     "Ros2InterfaceInfo",
 )
+load("@rules_cc//cc:defs.bzl", "cc_common")
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
 
 Ros2PluginInfo = provider(

--- a/ros2/rust_interfaces.bzl
+++ b/ros2/rust_interfaces.bzl
@@ -25,6 +25,7 @@ load(
     "idl_adapter_aspect",
     "run_generator",
 )
+load("@rules_cc//cc:defs.bzl", "cc_common")
 load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust/private:rustc.bzl", "rustc_compile_action")
 load(

--- a/ros2/test/rosbag/BUILD.bazel
+++ b/ros2/test/rosbag/BUILD.bazel
@@ -43,6 +43,7 @@ ros2_bag(
         env = {
             "STORAGE_ID": storage_id,
         },
+        flaky = True,
         idl_deps = [
             "@ros2_common_interfaces//:std_msgs",
             "@ros2_rcl_interfaces//:rcl_interfaces",


### PR DESCRIPTION
Bazel 9 drops the builtin CC and Python rules. This commit adds missing load statements and updates upstream packages to fixed versions.