### PR TITLE
Force rclcpp_lifecycle to be a shared lib

### DIFF
--- a/repositories/rclcpp.BUILD.bazel
+++ b/repositories/rclcpp.BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "rclcpp_interfaces",
 )
 load("@com_github_mvukov_rules_ros2//ros2:cc_defs.bzl", "ros2_cpp_library")
+load("@rules_cc//cc:defs.bzl", "cc_shared_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
 
@@ -109,11 +110,34 @@ ros2_cpp_library(
 )
 
 ros2_cpp_library(
-    name = "rclcpp_lifecycle",
-    srcs = glob([
-        "rclcpp_lifecycle/src/**/*.cpp",
+    name = "rclcpp_lifecycle_impl",
+    srcs = glob(["rclcpp_lifecycle/src/**/*.cpp"]),
+    hdrs = glob([
+        "rclcpp_lifecycle/include/**/*.hpp",
+        "rclcpp_lifecycle/include/**/*.h",
         "rclcpp_lifecycle/src/*.hpp",
     ]),
+    includes = [
+        "rclcpp_lifecycle/include",
+        "rclcpp_lifecycle/src",
+    ],
+    local_defines = ["RCLCPP_LIFECYCLE_BUILDING_DLL"],
+    deps = [
+        ":rclcpp",
+        "@ros2_rcl//:rcl_lifecycle",
+        "@ros2_rcl_interfaces//:c_lifecycle_msgs",
+        "@ros2_rcl_interfaces//:cpp_lifecycle_msgs",
+    ],
+)
+
+cc_shared_library(
+    name = "rclcpp_lifecycle_so",
+    deps = [":rclcpp_lifecycle_impl"],
+)
+
+ros2_cpp_library(
+    name = "rclcpp_lifecycle",
+    srcs = [":rclcpp_lifecycle_so"],
     hdrs = glob([
         "rclcpp_lifecycle/include/**/*.hpp",
         "rclcpp_lifecycle/include/**/*.h",


### PR DESCRIPTION
This PR forces rclcpp_lifecycle to link as a shared library.

rclcpp_lifecycle contains an [global variable](https://github.com/ros2/rclcpp/blob/humble/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp#L111) that is indirectly used by plugins and libraries. We want the plugin and libraries that uses the rclcpp_lifecycle to have the same global variable. Current statically linking behavior will result in plugin having its own global variable (its a .so) and library/node that loads the plugin having its own global variable. This fixes this issue by forcing rclcpp_lifecycle to link as a shared library. The Dynamic Linker ensures that only one instance of the library’s global data is mapped into the process memory. Now the both plugin and library/node will load rclcpp_lifecycle.so and will result in a single global variable. End result is that rclcpp_lifecycle node in the main binary can control the lifecycle of plugin and node itself. 

This PR is needed as ROS2_Control package controls its loaded ros2_plugins lifecycle from the main node. Without this PR, ros2_control_node will crash on runtime as it expects loaded ros2 plugins lifecycle be present in the global variable. In addition, dynamic loading of rclcpp_lifecycle is the default cmake ros2 behavior.