### PR TITLE
Remove Python 3.13 from supported versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,7 +35,6 @@ _PYTHON_VERSIONS = [
     "3.10",
     "3.11",
     "3.12",
-    "3.13",
 ]
 
 _DEFAULT_PYTHON = "3.10"


### PR DESCRIPTION
Numpy 2.1.0 (https://numpy.org/devdocs/release/2.1.0-notes.html) is the first Numpy to support Python 3.13.

However ROS2 Humble requires Numpy <2. To my understanding this is mostly due to cv_bridge / OpenCV dependencies which are compiled against Numpy 1 ABI.

Numpy 1.x is also pinned in
https://github.com/mvukov/rules_ros2/blob/78d85ff784d999bcd4dc288b6fd48e41e7710204/requirements.txt#L5

I'm trying to upgrade our Python interpreter to 3.13 currently and am running into an issue where some bazel query based checks choke on rules_ros2 failing to build a Numpy 2.3.5 from source due to https://github.com/bazel-contrib/rules_python/issues/824

This is a simple fix for our queries.

I'm not really sure how Python 3.13 would work with ROS2 Humble (@mering vis / https://github.com/mvukov/rules_ros2/pull/474)

But hopefully we can get https://github.com/mvukov/rules_ros2/pull/558 at some point (promise to try it soon :D)