### PR TITLE
Add explicit load statements

### DIFF
--- a/repositories/clang_configure.bzl
+++ b/repositories/clang_configure.bzl
@@ -17,6 +17,8 @@ def _clang_configure_impl(repository_ctx):
     repository_ctx.symlink(libclang_path, "libclang.so")
 
     repository_ctx.file("BUILD.bazel", """\
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+
 exports_files([
     "clang",
 ])

--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -17,6 +17,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@com_github_mvukov_rules_ros2//ros2:cc_opts.bzl", "C_COPTS")
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo", "py_library")
 load("@rules_ros2_pip_deps//:requirements.bzl", "requirement")
 

--- a/ros2/plugin.bzl
+++ b/ros2/plugin.bzl
@@ -29,6 +29,7 @@ load(
     "create_dynamic_library",
 )
 load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _ros2_plugin_impl(ctx):
     target_name = ctx.attr.name


### PR DESCRIPTION
The implicit ones have been removed in Bazel 9.

Contributes towards #602.