### PR TITLE
Remove -latomic from linkopts

### DIFF
--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -48,7 +48,6 @@ cmake(
         {
             ("@platforms//os:linux", "@platforms//os:macos"): [
                 "-lacl",
-                "-latomic",
                 "-lpthread",
                 "-lrt",
             ],

--- a/repositories/rclpy.BUILD.bazel
+++ b/repositories/rclpy.BUILD.bazel
@@ -18,7 +18,6 @@ ros2_cpp_binary(
     includes = ["rclpy/src"],
     linkopts = [
         "-fvisibility=hidden",
-        "-latomic",
     ],
     linkshared = True,
     deps = [


### PR DESCRIPTION
-latomic is needed on 32-bit ARM (armv7), where the compiler cannot inline 64-bit atomic operations as native instructions and must call out to GCC's libatomic runtime. On      
  x86_64 and aarch64 — the targets rules_ros2 supports — the CPU provides native atomic instructions and the compiler always inlines them, making -latomic unused at runtime.      
                                                                  
  Removing it has two benefits:                                                                                                                                                    
  - Fixes compatibility with `zig cc` (used by as [hermetic_cc_toolchain](https://github.com/uber/hermetic_cc_toolchain/)) that do not bundle libatomic as a system library, causing link failures when -latomic is
  present                                                                                                                                                                          
  - Removes an unnecessary link-time dependency on platforms where it has no effect
                                                                                                                                                                                   
  If armv7 support is ever needed, -latomic can be reintroduced conditionally with select({"@platforms//cpu:armv7": ["-latomic"], "//conditions:default": []}).  