### PR TITLE
Use cmake --parallel instead of hardcoded -j4

### DIFF
--- a/repositories/curl.BUILD.bazel
+++ b/repositories/curl.BUILD.bazel
@@ -12,8 +12,7 @@ filegroup(
 cmake(
     name = "curl",
     build_args = [
-        "--",
-        "-j4",
+        "--parallel",
     ],
     cache_entries = {
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!

--- a/repositories/cyclonedds.BUILD.bazel
+++ b/repositories/cyclonedds.BUILD.bazel
@@ -138,8 +138,7 @@ cache_entries_without_shm = {
 cmake(
     name = "cyclonedds",
     build_args = [
-        "--",
-        "-j4",
+        "--parallel",
     ],
     cache_entries = select(
         {

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -25,8 +25,7 @@ cache_entries_qnx = {
 cmake(
     name = "iceoryx",
     build_args = [
-        "--",  # <- Pass options to the native tool.
-        "-j4",
+        "--parallel",
     ],
     cache_entries = selects.with_or(
         {

--- a/repositories/yaml-cpp.BUILD.bazel
+++ b/repositories/yaml-cpp.BUILD.bazel
@@ -12,8 +12,7 @@ filegroup(
 cmake(
     name = "yaml-cpp",
     build_args = [
-        "--",
-        "-j4",
+        "--parallel",
     ],
     cache_entries = {
         "BUILD_SHARED_LIBS": "OFF",

--- a/repositories/zstd.BUILD.bazel
+++ b/repositories/zstd.BUILD.bazel
@@ -12,8 +12,7 @@ filegroup(
 cmake(
     name = "zstd",
     build_args = [
-        "--",
-        "-j4",
+        "--parallel",
     ],
     cache_entries = {
         "ZSTD_BUILD_PROGRAMS": "OFF",


### PR DESCRIPTION
Several cmake builds pass `-- -j4` to the underlying build tool (Ninja), capping parallelism at 4 jobs regardless of how many CPUs are available. On machines with many cores this is a significant bottleneck.                                                        
                                                                                                                                                
This PR replaces them with cmake --parallel (introduced in CMake 3.12), which auto-detects available cores and passes the appropriate flag to the underlying build tool without hardcoding a limit.                         
                                                                                                                                  
# Measured impact                                                 

  Profiled with bazel build --profile on a 96-core Linux machine. Both iceoryx and cyclonedds were previously bottlenecked at 4/96 cores:       
   
```
  ┌───────────────────┬──────────────┬────────────────────┐                                                                                     
  │      Action       │ Before (-j4) │ After (--parallel) │       
  ├───────────────────┼──────────────┼────────────────────┤                                                                                     
  │ CMake: iceoryx    │ 41s          │ 16s                │       
  ├───────────────────┼──────────────┼────────────────────┤
  │ CMake: cyclonedds │ 13s          │ 8s                 │                                                                                     
  └───────────────────┴──────────────┴────────────────────┘
```                                                                                                                                                
  On machines with fewer cores the change is a no-op — cmake --parallel without a count uses a reasonable default that scales down              
  appropriately.
                                                                                                                                                
  CMake version requirement                                       

  --parallel was added in CMake 3.12 (released June 2018). Both iceoryx and cyclonedds already require CMake versions well above that threshold.