### PR TITLE
fix: add required_providers to idl_adapter_aspect

### DIFF
--- a/ros2/interfaces.bzl
+++ b/ros2/interfaces.bzl
@@ -154,6 +154,7 @@ def _idl_adapter_aspect_impl(target, ctx):
 idl_adapter_aspect = aspect(
     implementation = _idl_adapter_aspect_impl,
     attr_aspects = ["deps"],
+    required_providers = [Ros2InterfaceInfo],
     attrs = {
         "_adapter": attr.label(
             default = Label("@ros2_rosidl//:rosidl_adapter_app"),


### PR DESCRIPTION
## Problem

`idl_adapter_aspect` has `attr_aspects = ["deps"]` but no `required_providers`, so it propagates into **all** transitive deps — including pip packages (e.g. `lark-parser`) that do not carry `Ros2InterfaceInfo`. The aspect implementation unconditionally accesses `target[Ros2InterfaceInfo]`, which crashes on those targets.

This surfaces during cross-compilation (e.g. `--platforms=linux_aarch64`) where `py_ros2_interface_library` targets pull pip packages into their transitive dep graph.

## Fix

Add `required_providers = [Ros2InterfaceInfo]` to `idl_adapter_aspect`, making it a no-op for any target that does not carry the ROS interface provider.

Other aspects in the same file — `c_generator_aspect` (line 487) and `py_generator_aspect` (line 650) — already set `required_providers = [Ros2InterfaceInfo]` correctly. This brings `idl_adapter_aspect` into line with them.

## Change

```starlark
idl_adapter_aspect = aspect(
    implementation = _idl_adapter_aspect_impl,
    attr_aspects = ["deps"],
+   required_providers = [Ros2InterfaceInfo],
    ...
)
```