### PR TITLE
Pre-declaring the output of py_launcher_rule

### DIFF
--- a/ros2/ament.bzl
+++ b/ros2/ament.bzl
@@ -265,7 +265,7 @@ def py_create_ament_setup(ament_prefix_path):
     return "os.environ['AMENT_PREFIX_PATH'] = '{}'".format(ament_prefix_path)
 
 def _py_launcher_rule_impl(ctx):
-    output = ctx.actions.declare_file(ctx.attr.name + ".py")
+    output = ctx.outputs.output
     ament_prefix_path = ctx.attr.ament_setup[Ros2AmentSetupInfo].ament_prefix_path
 
     substitutions = dicts.add(
@@ -308,6 +308,7 @@ py_launcher_rule = rule(
             mandatory = True,
             allow_single_file = True,
         ),
+        "output": attr.output(mandatory = True),
     },
     implementation = _py_launcher_rule_impl,
 )
@@ -332,6 +333,7 @@ def py_launcher(name, deps, idl_deps = None, **kwargs):
         The label of the expanded .py file (`name + ".py"`).
     """
     ament_setup = name + "_ament_setup"
+    output_name = name + ".py"
     testonly = kwargs.get("testonly", False)
     ros2_ament_setup(
         name = ament_setup,
@@ -343,9 +345,10 @@ def py_launcher(name, deps, idl_deps = None, **kwargs):
     py_launcher_rule(
         name = name,
         ament_setup = ament_setup,
+        output = output_name,
         **kwargs
     )
-    return name + ".py"
+    return output_name
 
 def split_kwargs(**kwargs):
     """Split kwargs into those to be forwarded to the actual binary target and launcher target respectively."""


### PR DESCRIPTION
The generated _launch.py by `py_launcher_rule` is consumed in `ros2_launch` macro by a `py_binary` target as its `main`. This caused bazel to think that it's a "source file" in bazel query:

```
source file //some/package:foo_launch.py
```

CI jobs that build targets based on bazel query result (e.g., using bazel-diff) will try to build `//some/package:foo_launch.py` and get errors like:

```
//some/package:foo_launch.py: missing input file '//some/package:foo_launch.py'
```

This PR fix it by explicitly declaring the generated _launch.py name as the output, so Bazel knows that it's a generated file:

```
generated file //some/package:foo_launch.py
```

This also makes `py_launcher` more robust: instead of assuming the generated file name of `py_launcher_rule`, it passes the name to `py_launcher_rule` explicitly.