### PR TITLE
Replacing experimental_target_platforms with target_platforms

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,13 +55,13 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 [
     pip.parse(
         experimental_index_url = "https://pypi.org/simple",
-        experimental_target_platforms = [
-            "cp{}_linux_aarch64".format(python_version.replace(".", "")),
-            "cp{}_linux_x86_64".format(python_version.replace(".", "")),
-        ],
         hub_name = "rules_ros2_pip_deps",
         python_version = python_version,
         requirements_lock = "//:requirements_lock.txt",
+        target_platforms = [
+            "linux_aarch64",
+            "linux_x86_64",
+        ],
     )
     for python_version in _PYTHON_VERSIONS
 ]


### PR DESCRIPTION
rules_python 2.x derives the hub's per-platform wheel aliases from `target_platforms`; the legacy `experimental_target_platforms` is no longer read by the bzlmod hub builder, so without having aarch64 in `target_platforms`,  cross-compiles get an x86_64-only hub and fail wheel resolution.
