### PR TITLE
Move -latomic linkopts from repository BUILD rules to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,6 +47,7 @@ test --test_output=errors
 build:clang --repo_env=CC=clang
 build:clang --repo_env=CXX=clang++
 build:clang --linkopt="-fuse-ld=lld"
+build:clang --linkopt="-latomic"
 
 # Work around https://github.com/bazelbuild/rules_rust/issues/2125
 build --action_env=CARGO_BAZEL_REPIN=1

--- a/repositories/iceoryx.BUILD.bazel
+++ b/repositories/iceoryx.BUILD.bazel
@@ -48,11 +48,10 @@ cmake(
         {
             ("@platforms//os:linux", "@platforms//os:macos"): [
                 "-lacl",
-                "-latomic",
                 "-lpthread",
                 "-lrt",
             ],
-            ("@platforms//os:android", "@platforms//os:qnx"): ["-latomic"],
+            ("@platforms//os:android", "@platforms//os:qnx"): [],
         },
         no_match_error = "Supported OSs: Android, Linux, macOS, QNX",
     ),

--- a/repositories/rclpy.BUILD.bazel
+++ b/repositories/rclpy.BUILD.bazel
@@ -18,7 +18,6 @@ ros2_cpp_binary(
     includes = ["rclpy/src"],
     linkopts = [
         "-fvisibility=hidden",
-        "-latomic",
     ],
     linkshared = True,
     deps = [


### PR DESCRIPTION
`-latomic` was originally hardcoded directly in `rclpy.BUILD.bazel` and `iceoryx.BUILD.bazel` to resolve `__atomic_*` undefined reference errors when testing against system Clang on Ubuntu via `--config=clang` in CI.

However, hardcoding `-latomic` directly inside exported target BUILD files forces all downstream consumers of `@ros2_rclpy` and `@ros2_iceoryx` to link against `libatomic`. When downstream projects use hermetic LLVM/Clang toolchains or platforms where `libatomic` is missing entirely, this causes fatal `cannot find -latomic` linker errors downstream.

To resolve this across the repository while preserving upstream CI, this PR:
- Removes `-latomic` from `repositories/rclpy.BUILD.bazel`.
- Removes `-latomic` from `repositories/iceoryx.BUILD.bazel`.
- Adds `build:clang --linkopt="-latomic"` to existing linkopts in `.bazelrc`.