### PR TITLE
Expose noop rcl_logging implementation

### DIFF
--- a/repositories/rcl.BUILD.bazel
+++ b/repositories/rcl.BUILD.bazel
@@ -30,6 +30,7 @@ ros2_c_library(
     hdrs = glob(["rcl/include/**/*.h"]),
     implementation_deps = select(
         {
+            "@com_github_mvukov_rules_ros2//ros2:rcl_logging_noop": ["@ros2_rcl_logging//:rcl_logging_noop"],
             "@com_github_mvukov_rules_ros2//ros2:rcl_logging_spdlog": ["@ros2_rcl_logging//:rcl_logging_spdlog"],
             "@com_github_mvukov_rules_ros2//ros2:rcl_logging_syslog": ["@ros2_rcl_logging_syslog//:rcl_logging_syslog"],
         },

--- a/repositories/rcl_logging.BUILD.bazel
+++ b/repositories/rcl_logging.BUILD.bazel
@@ -15,6 +15,16 @@ ros2_c_library(
 )
 
 ros2_cpp_library(
+    name = "rcl_logging_noop",
+    srcs = ["rcl_logging_noop/src/rcl_logging_noop/rcl_logging_noop.cpp"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":rcl_logging_interface",
+        "@ros2_rcutils//:rcutils",
+    ],
+)
+
+ros2_cpp_library(
     name = "rcl_logging_spdlog",
     srcs = glob(["rcl_logging_spdlog/src/*.cpp"]),
     implementation_deps = [

--- a/ros2/BUILD.bazel
+++ b/ros2/BUILD.bazel
@@ -38,9 +38,16 @@ string_flag(
     name = "rcl_logging_impl",
     build_setting_default = "spdlog",
     values = [
+        "noop",
         "spdlog",
         "syslog",
     ],
+)
+
+config_setting(
+    name = "rcl_logging_noop",
+    flag_values = {":rcl_logging_impl": "noop"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(


### PR DESCRIPTION
Adds rcl_logging_noop target and wires it up as a selectable rcl_logging_impl option alongside spdlog and syslog.