### PR TITLE
Dedup ros2_ament_setup outputs

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -30,3 +30,6 @@ common --color=yes
 
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME
+
+# The default of 3 is not good enough, make Bazel try harder
+test --flaky_test_attempts=10

--- a/ros2/ament.bzl
+++ b/ros2/ament.bzl
@@ -195,6 +195,14 @@ def _ros2_ament_setup_rule_impl(ctx):
         ] + [idls_from_deps],
     ).to_list()
 
+    # Track generated and symlinked files to dedup outputs. It can happen that Ros2PluginCollectorAspectInfo sees a
+    # target such as builtin_interfaces multiple times via different edges of the dependency graph.  Those different
+    # paths can be introduced via config transitions (one concrete example is a C++ node with some IDL deps and a Python
+    # node that shares at least one of those IDL deps; when the Python node uses aspect_rules_py, it lands on a
+    # different configuration, because aspect_rules_py introduces their python_transition). Deduping here is an easy
+    # fix.
+    output_paths = {}
+
     for idl in idls:
         package_name = idl.package_name
         if package_name not in registered_packages:
@@ -205,9 +213,11 @@ def _ros2_ament_setup_rule_impl(ctx):
             if src.extension not in ("msg", "srv", "action"):
                 continue
             subdir = src.extension
-            src_file = ctx.actions.declare_file(
-                paths.join(prefix_path, "share", package_name, subdir, src.basename),
-            )
+            src_file_path = paths.join(prefix_path, "share", package_name, subdir, src.basename)
+            if src_file_path in output_paths:
+                continue
+            output_paths[src_file_path] = True
+            src_file = ctx.actions.declare_file(src_file_path)
             ctx.actions.symlink(
                 output = src_file,
                 target_file = src,
@@ -219,21 +229,26 @@ def _ros2_ament_setup_rule_impl(ctx):
         # mcap supports both IDL and msg definitions, but not combinations. Therefore, if any handwritten IDL files are
         # present, the rosbag writer also needs any generated IDL files it depends on.
         if idl.idl_files != None:
-            for idl in idl.idl_files:
-                subdir = idl.dirname.split("/")[-1]
-                src_file = ctx.actions.declare_file(
-                    paths.join(prefix_path, "share", package_name, subdir, idl.basename),
-                )
+            for idl_file in idl.idl_files:
+                subdir = idl_file.dirname.split("/")[-1]
+                src_file_path = paths.join(prefix_path, "share", package_name, subdir, idl_file.basename)
+                if src_file_path in output_paths:
+                    continue
+                output_paths[src_file_path] = True
+                src_file = ctx.actions.declare_file(src_file_path)
+
                 ctx.actions.symlink(
                     output = src_file,
-                    target_file = idl,
+                    target_file = idl_file,
                 )
                 outputs.append(src_file)
                 idl_manifest_contents.append(paths.join(subdir, src.basename))
 
-        idl_manifest = ctx.actions.declare_file(
-            paths.join(prefix_path, _RESOURCE_INDEX_PATH, "rosidl_interfaces", package_name),
-        )
+        idl_manifest_path = paths.join(prefix_path, _RESOURCE_INDEX_PATH, "rosidl_interfaces", package_name)
+        if idl_manifest_path in output_paths:
+            continue
+        output_paths[idl_manifest_path] = True
+        idl_manifest = ctx.actions.declare_file(idl_manifest_path)
         ctx.actions.write(idl_manifest, "\n".join([p for p in idl_manifest_contents]))
         outputs.append(idl_manifest)
 

--- a/ros2/pytest_wrapper.py.tpl
+++ b/ros2/pytest_wrapper.py.tpl
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import sys
+import zlib
 
 import coverage
 import pytest
@@ -38,6 +39,14 @@ def main() -> None:
         os.environ['ROS_HOME'] = bazel_test_output_dir
     if 'ROS_LOG_DIR' not in os.environ:
         os.environ['ROS_LOG_DIR'] = bazel_test_output_dir
+    if 'ROS_DOMAIN_ID' not in os.environ:
+        # Bazel sandbox network isolation uses user namespaces via linux-sandbox,
+        # which is typically not available in a Docker container, where Bazel falls
+        # back to processwrapper-sandbox. In this case concurrently-running tests
+        # can see each others DDS messages. Set the DOMAIN_ID explicitly to avoid
+        # this (valid domain IDs are in the range 0..232).
+        domain_seed = os.environ.get('TEST_TMPDIR', '') + os.environ.get('TEST_RANDOM_SEED', '')
+        os.environ['ROS_DOMAIN_ID'] = str(zlib.crc32(domain_seed.encode()) % 232)
 
     bazel_coverage = os.getenv('COVERAGE') == '1'
 

--- a/ros2/test.py.tpl
+++ b/ros2/test.py.tpl
@@ -1,5 +1,6 @@
 import os
 import sys
+import zlib
 
 import launch_testing.launch_test
 import launch_testing_ros
@@ -22,6 +23,14 @@ if 'ROS_HOME' not in os.environ:
     os.environ['ROS_HOME'] = bazel_test_output_dir
 if 'ROS_LOG_DIR' not in os.environ:
     os.environ['ROS_LOG_DIR'] = bazel_test_output_dir
+if 'ROS_DOMAIN_ID' not in os.environ:
+    # Bazel sandbox network isolation uses user namespaces via linux-sandbox,
+    # which is typically not available in a Docker container, where Bazel falls
+    # back to processwrapper-sandbox. In this case concurrently-running tests
+    # can see each others DDS messages. Set the DOMAIN_ID explicitly to avoid
+    # this (valid domain IDs are in the range 0..232).
+    domain_seed = os.environ.get('TEST_TMPDIR', '') + os.environ.get('TEST_RANDOM_SEED', '')
+    os.environ['ROS_DOMAIN_ID'] = str(zlib.crc32(domain_seed.encode()) % 232)
 
 parser, args = launch_testing.launch_test.parse_arguments()
 exit_code = launch_testing.launch_test.run(

--- a/ros2/test/rosbag/BUILD.bazel
+++ b/ros2/test/rosbag/BUILD.bazel
@@ -43,7 +43,6 @@ ros2_bag(
         env = {
             "STORAGE_ID": storage_id,
         },
-        flaky = True,
         idl_deps = [
             "@ros2_common_interfaces//:std_msgs",
             "@ros2_rcl_interfaces//:rcl_interfaces",

--- a/ros2/test/rust/BUILD.bazel
+++ b/ros2/test/rust/BUILD.bazel
@@ -46,7 +46,6 @@ rust_binary(
 ros2_test(
     name = "tests",
     size = "small",
-    flaky = True,
     launch_file = "tests.py",
     nodes = [
         ":publisher",


### PR DESCRIPTION
It can happen that ros2_ament_setup sees the same IDL deps multiple times (via different config transitions). In that case symlinks are created multiple times, leading to errors. Introduce a fix by deduping ros2_ament_setup's output.